### PR TITLE
Various fixes and improvements for non-Windows systems.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -150,7 +150,7 @@ void ppc_expection_handler(uint32_t exception_type, uint32_t handle_args){
     printf("MSR VALUE: %x \n Exception Type: %x", ppc_state.ppc_msr, exception_type);
 
     //Check ROM Exception Prefix
-    if (ppc_state.ppc_msr && 0x40){
+    if (ppc_state.ppc_msr & 0x40){
         ppc_next_instruction_address |= 0xFFF00000;
     }
     else{

--- a/makefile
+++ b/makefile
@@ -9,8 +9,8 @@ LFLAGS	 =
 all: $(OBJS)
 	$(CC) -g $(OBJS) -o $(OUT) $(LFLAGS)
 
-main.o: main.c
-	$(CC) $(FLAGS) main.c 
+main.o: main.cpp
+	$(CC) $(FLAGS) main.cpp
 
 macioserial.o: macioserial.cpp
 	$(CC) $(FLAGS) macioserial.cpp 

--- a/makefile
+++ b/makefile
@@ -1,10 +1,10 @@
 OBJS	= main.o macioserial.o macscsi.o macswim3.o mpc106.o openpic.o poweropcodes.o ppcfpopcodes.o ppcgekkoopcodes.o ppcmemory.o ppcopcodes.o viacuda.o
 SOURCE	= main.c macioserial.cpp macscsi.cpp macswim3.cpp mpc106.cpp openpic.cpp poweropcodes.cpp ppcfpopcodes.cpp ppcgekkoopcodes.cpp ppcmemory.cpp ppcopcodes.cpp viacuda.cpp
 HEADER	= macioserial.h macscsi.h macswim3.h mpc106.h openpic.h ppcemumain.h ppcmemory.h viacuda.h
-OUT	= dingusppc
-CC	 = g++
-FLAGS	 = -g -c -Wall
-LFLAGS	 = 
+OUT	    = dingusppc
+CC	    = g++
+FLAGS	= -g -c -Wall -std=c++11
+LFLAGS	=
 
 all: $(OBJS)
 	$(CC) -g $(OBJS) -o $(OUT) $(LFLAGS)

--- a/ppcemumain.h
+++ b/ppcemumain.h
@@ -584,7 +584,7 @@ static std::map<uint8_t, PPCOpcode> OpcodeGrabber =
      {28, &ppc_andidot},   {29, &ppc_andisdot},  {30, &ppc_illegalop}, {31, &ppc_opcode31},
      {32, &ppc_lwz},       {33, &ppc_lwzu},      {34, &ppc_lbz},       {35, &ppc_lbzu},
      {36, &ppc_stw},       {37, &ppc_stwu},      {38, &ppc_stb},       {39, &ppc_stbu},
-     {40, &ppc_lhz},       {41, &ppc_lhzu},      {42, &ppc_lha},       {42, &ppc_lhau},
+     {40, &ppc_lhz},       {41, &ppc_lhzu},      {42, &ppc_lha},       {43, &ppc_lhau},
      {44, &ppc_sth},       {45, &ppc_sthu},      {46, &ppc_lmw},       {47, &ppc_stmw},
      {48, &ppc_lfs},       {49, &ppc_lfsu},      {50, &ppc_lfd},       {51, &ppc_lfdu},
      {52, &ppc_stfs},      {53, &ppc_stfsu},     {54, &ppc_stfd},      {55, &ppc_stfdu},

--- a/ppcfpopcodes.cpp
+++ b/ppcfpopcodes.cpp
@@ -637,7 +637,7 @@ void ppc_fcmpo(){
 
     if ((db_test_a == snan) || (db_test_b == snan)){
         ppc_state.ppc_fpscr |= 0x1000000;
-        if (ppc_state.ppc_fpscr && 0x80){
+        if (ppc_state.ppc_fpscr & 0x80){
             ppc_state.ppc_fpscr |= 0x80000;
         }
     }

--- a/ppcmemory.cpp
+++ b/ppcmemory.cpp
@@ -111,7 +111,7 @@ void msr_status_update(){
 void ibat_update(){
     uint8_t tlb_place = 0;
     uint32_t ref_area = 0;
-    bool msr_pr = ppc_state.ppc_msr && 4000; //This is for problem mode; make sure that supervisor mode does not touch this!
+    bool msr_pr = ppc_state.ppc_msr & 4000; //This is for problem mode; make sure that supervisor mode does not touch this!
     for (int bat_srch = 528; bat_srch < 535; bat_srch += 2){
         ref_area = ((ppc_state.ppc_spr[bat_srch] & 0x1FFC) > 0) ? ((ppc_state.ppc_spr[bat_srch] & 0x1FFC) << 16): 131072;
         bepi_chk|= (ppc_effective_address & 0xFFFE0000) & ~ref_area;
@@ -132,7 +132,7 @@ void ibat_update(){
 void dbat_update(){
     uint8_t tlb_place = 0;
     uint32_t ref_area = 0;
-    bool msr_pr = ppc_state.ppc_msr && 4000; //This is for problem mode; make sure that supervisor mode does not touch this!
+    bool msr_pr = ppc_state.ppc_msr & 4000; //This is for problem mode; make sure that supervisor mode does not touch this!
     for (int bat_srch = 536; bat_srch < 543; bat_srch += 2){
         ref_area = (ppc_state.ppc_spr[bat_srch] & 0x1FFC) > 0? ((ppc_state.ppc_spr[bat_srch] & 0x1FFC) << 16): 131072;
         bepi_chk|= (ppc_effective_address & 0xFFFE0000) & ~ref_area;
@@ -334,7 +334,7 @@ void primary_hash_check(uint32_t vpid_known){
 
         check_vpid = (check_vpid >> 7) & 0xFFFFFF;
 
-        if ((check_vpid >> 31) && 0x01){
+        if ((check_vpid >> 31) & 0x01){
             if (vpid_known == check_vpid){
                 hash_found = true;
                 pteg_answer |= grab_pteg1_ptr[pte_word1++] << 24;
@@ -376,7 +376,7 @@ void secondary_hash_check(uint32_t vpid_known){
 
         check_vpid = (check_vpid >> 7) & 0xFFFFFF;
 
-        if ((check_vpid >> 31) && 0x01){
+        if ((check_vpid >> 31) & 0x01){
             if (vpid_known == check_vpid){
                 hash_found = true;
                 pteg_answer |= grab_pteg2_ptr[pte_word2++] << 24;
@@ -444,7 +444,7 @@ void address_quickinsert_translate(uint32_t address_grab, uint32_t value_insert,
         pteg_to_go = 1;
 
         for (uint32_t grab_loop = 0; grab_loop < 4; grab_loop++){
-            if ((dbat_array_map[grab_loop][0] >> 1) && 0x1){
+            if ((dbat_array_map[grab_loop][0] >> 1) & 0x1){
                 min_val = dbat_array_map[grab_loop][1];
                 max_val = dbat_array_map[grab_loop][2];
                 if ((address_grab >= min_val) && (address_grab < max_val) && (max_val != 0)){
@@ -666,7 +666,7 @@ void address_quickgrab_translate(uint32_t address_grab, uint32_t value_extract, 
         pteg_to_go = 1;
 
         for (uint32_t grab_loop = 0; grab_loop < 4; grab_loop++){
-            if (dbat_array_map[grab_loop][0] && 0x1){
+            if (dbat_array_map[grab_loop][0] & 0x1){
                 min_val = dbat_array_map[grab_loop][1];
                 max_val = dbat_array_map[grab_loop][2];
                 if ((address_grab >= min_val) && (address_grab <= max_val) && (max_val != 0)){
@@ -870,7 +870,7 @@ void quickinstruction_translate(uint32_t address_grab){
         pteg_to_go = 1;
 
         for (uint32_t grab_loop = 0; grab_loop < 4; grab_loop++){
-            if (ibat_array_map[grab_loop][0] && 0x1){
+            if (ibat_array_map[grab_loop][0] & 0x1){
                 min_val = ibat_array_map[grab_loop][1];
                 max_val = ibat_array_map[grab_loop][2];
                 if ((address_grab >= min_val) && (address_grab <= max_val) && (max_val != 0)){

--- a/ppcopcodes.cpp
+++ b/ppcopcodes.cpp
@@ -188,7 +188,7 @@ void ppc_setsoov(uint32_t a, uint32_t b){
         ppc_state.ppc_spr[1] &= 0xBFFFFFFF;
     }
 
-    if (((a64b + b64b) < 0x80000000) || (ppc_state.ppc_spr[1] && 0x40000000)){
+    if (((a64b + b64b) < 0x80000000) || (ppc_state.ppc_spr[1] & 0x40000000)){
         ppc_state.ppc_spr[1] |= 0x80000000;
     }
     else{
@@ -384,7 +384,7 @@ void ppc_addcodot(){
 
 void ppc_adde(){
     ppc_grab_regsdab();
-    uint32_t grab_xer = ppc_state.ppc_spr[1] && 0x20000000;
+    uint32_t grab_xer = ppc_state.ppc_spr[1] & 0x20000000;
     ppc_result_d = ppc_result_a + ppc_result_b + grab_xer;
     if (((grab_xer != 0) && (grab_xer > (~(ppc_result_b + ppc_result_a)))) || (ppc_result_d > ~ppc_result_a)){
         ppc_state.ppc_spr[1] |= 0x20000000;
@@ -397,7 +397,7 @@ void ppc_adde(){
 
 void ppc_addedot(){
     ppc_grab_regsdab();
-    uint32_t grab_xer = ppc_state.ppc_spr[1] && 0x20000000;
+    uint32_t grab_xer = ppc_state.ppc_spr[1] & 0x20000000;
     ppc_result_d = ppc_result_a + ppc_result_b + grab_xer;
     ppc_changecrf0(ppc_result_d);
     if (((ppc_result_b + grab_xer) < ppc_result_b) || (ppc_result_d < ppc_result_a)){
@@ -411,7 +411,7 @@ void ppc_addedot(){
 
 void ppc_addeo(){
     ppc_grab_regsdab();
-    uint32_t grab_xer = ppc_state.ppc_spr[1] && 0x20000000;
+    uint32_t grab_xer = ppc_state.ppc_spr[1] & 0x20000000;
     ppc_setsoov(ppc_result_a, ppc_result_b + grab_xer);
     ppc_result_d = ppc_result_a + ppc_result_b + grab_xer;
     if (((ppc_result_b + grab_xer) < ppc_result_b) || (ppc_result_d < ppc_result_a)){
@@ -425,7 +425,7 @@ void ppc_addeo(){
 
 void ppc_addeodot(){
     ppc_grab_regsdab();
-    uint32_t grab_xer = ppc_state.ppc_spr[1] && 0x20000000;
+    uint32_t grab_xer = ppc_state.ppc_spr[1] & 0x20000000;
     ppc_setsoov(ppc_result_a, ppc_result_b + grab_xer);
     ppc_result_d = ppc_result_a + ppc_result_b + grab_xer;
     if (((ppc_result_b + grab_xer) < ppc_result_b) || (ppc_result_d < ppc_result_a)){
@@ -440,7 +440,7 @@ void ppc_addeodot(){
 
 void ppc_addme(){
     ppc_grab_regsda();
-    uint32_t grab_xer = ppc_state.ppc_spr[1] && 0x20000000;
+    uint32_t grab_xer = ppc_state.ppc_spr[1] & 0x20000000;
     ppc_result_d = ppc_result_a + grab_xer - 1;
     if  ((grab_xer - 1) > ~ppc_result_a){
         ppc_state.ppc_spr[1] |= 0x20000000;
@@ -453,7 +453,7 @@ void ppc_addme(){
 
 void ppc_addmedot(){
     ppc_grab_regsda();
-    uint32_t grab_xer = ppc_state.ppc_spr[1] && 0x20000000;
+    uint32_t grab_xer = ppc_state.ppc_spr[1] & 0x20000000;
     ppc_result_d = ppc_result_a + grab_xer - 1;
     if  ((grab_xer - 1) > ~ppc_result_a){
         ppc_state.ppc_spr[1] |= 0x20000000;
@@ -467,7 +467,7 @@ void ppc_addmedot(){
 
 void ppc_addmeo(){
     ppc_grab_regsda();
-    uint32_t grab_xer = ppc_state.ppc_spr[1] && 0x20000000;
+    uint32_t grab_xer = ppc_state.ppc_spr[1] & 0x20000000;
     ppc_setsoov(ppc_result_a, grab_xer);
     ppc_result_d = ppc_result_a + grab_xer - 1;
     if  ((grab_xer - 1) > ~ppc_result_a){
@@ -481,7 +481,7 @@ void ppc_addmeo(){
 
 void ppc_addmeodot(){
     ppc_grab_regsda();
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     ppc_setsoov(ppc_result_a, grab_xer);
     ppc_result_d = ppc_result_a + grab_xer - 1;
     ppc_changecrf0(ppc_result_d);
@@ -496,7 +496,7 @@ void ppc_addmeodot(){
 
 void ppc_addze(){
     ppc_grab_regsda();
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     ppc_result_d = ppc_result_a + grab_xer;
     if (grab_xer > ~ppc_result_a){
         ppc_state.ppc_spr[1] |= 0x20000000;
@@ -509,7 +509,7 @@ void ppc_addze(){
 
 void ppc_addzedot(){
     ppc_grab_regsda();
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     ppc_result_d = ppc_result_a + grab_xer;
     if (grab_xer > ~ppc_result_a){
         ppc_state.ppc_spr[1] |= 0x20000000;
@@ -523,7 +523,7 @@ void ppc_addzedot(){
 
 void ppc_addzeo(){
     ppc_grab_regsda();
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     ppc_setsoov(ppc_result_a, grab_xer);
     ppc_result_d = ppc_result_a + grab_xer;
     if (grab_xer > ~ppc_result_a){
@@ -537,7 +537,7 @@ void ppc_addzeo(){
 
 void ppc_addzeodot(){
     ppc_grab_regsda();
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     ppc_setsoov(ppc_result_a, grab_xer);
     ppc_result_d = ppc_result_a + grab_xer;
     if (grab_xer > ~ppc_result_a){
@@ -657,9 +657,9 @@ void ppc_subfic(){
 
 void ppc_subfe(){
     ppc_grab_regsdab();
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     not_this = ~ppc_result_a;
-    ppc_result_d = not_this + ppc_result_b + (ppc_state.ppc_spr[1] && 0x20000000);
+    ppc_result_d = not_this + ppc_result_b + (ppc_state.ppc_spr[1] & 0x20000000);
     if (ppc_result_d < (not_this + grab_xer)){
         ppc_state.ppc_spr[1] |= 0x20000000;
     }
@@ -672,7 +672,7 @@ void ppc_subfe(){
 
 void ppc_subfedot(){
     ppc_grab_regsdab();
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     not_this = ~ppc_result_a;
     ppc_result_d = not_this + ppc_result_b + grab_xer;
     if (ppc_result_d < (not_this + grab_xer)){
@@ -690,7 +690,7 @@ void ppc_subfedot(){
 void ppc_subfme(){
     ppc_grab_regsda();
     not_this = ~ppc_result_a;
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     ppc_result_d = not_this + grab_xer - 1;
     if (ppc_result_a || grab_xer){
         ppc_state.ppc_spr[1] |= 0x20000000;
@@ -705,7 +705,7 @@ void ppc_subfme(){
 void ppc_subfmedot(){
     ppc_grab_regsda();
     not_this = ~ppc_result_a;
-    uint32_t grab_xer = (ppc_state.ppc_spr[1] && 0x20000000);
+    uint32_t grab_xer = (ppc_state.ppc_spr[1] & 0x20000000);
     ppc_result_d = not_this + grab_xer - 1;
     if (ppc_result_d < (not_this + grab_xer)){
         ppc_state.ppc_spr[1] |= 0x20000000;
@@ -721,28 +721,28 @@ void ppc_subfmedot(){
 void ppc_subfze(){
     ppc_grab_regsda();
     not_this = ~ppc_result_a;
-    ppc_result_d = not_this + (ppc_state.ppc_spr[1] && 0x20000000);
+    ppc_result_d = not_this + (ppc_state.ppc_spr[1] & 0x20000000);
     if (ppc_result_d < not_this){
         ppc_state.ppc_spr[1] |= 0x20000000;
     }
     else{
         ppc_state.ppc_spr[1] &= 0xDFFFFFFF;
     }
-    ppc_carry(ppc_result_a, (ppc_state.ppc_spr[1] && 0x20000000));
+    ppc_carry(ppc_result_a, (ppc_state.ppc_spr[1] & 0x20000000));
     ppc_store_result_regd();
 }
 
 void ppc_subfzedot(){
     ppc_grab_regsda();
     not_this = ~ppc_result_a;
-    ppc_result_d = not_this + (ppc_state.ppc_spr[1] && 0x20000000);
+    ppc_result_d = not_this + (ppc_state.ppc_spr[1] & 0x20000000);
     if (ppc_result_d < not_this){
         ppc_state.ppc_spr[1] |= 0x20000000;
     }
     else{
         ppc_state.ppc_spr[1] &= 0xDFFFFFFF;
     }
-    ppc_carry(ppc_result_a, (ppc_state.ppc_spr[1] && 0x20000000));
+    ppc_carry(ppc_result_a, (ppc_state.ppc_spr[1] & 0x20000000));
     ppc_changecrf0(ppc_result_d);
     ppc_store_result_regd();
 }
@@ -1221,7 +1221,7 @@ void ppc_mfcr(){
 }
 
 void ppc_mtsr(){
-    if ((ppc_state.ppc_msr && 0x4000) == 0){
+    if ((ppc_state.ppc_msr & 0x4000) == 0){
         reg_s = (ppc_cur_instruction >> 21) & 31;
         grab_sr = (ppc_cur_instruction >> 16) & 15;
         ppc_state.ppc_sr[grab_sr] = ppc_state.ppc_gpr[reg_s];
@@ -1229,7 +1229,7 @@ void ppc_mtsr(){
 }
 
 void ppc_mtsrin(){
-    if ((ppc_state.ppc_msr && 0x4000) == 0){
+    if ((ppc_state.ppc_msr & 0x4000) == 0){
         ppc_grab_regssb();
         grab_sr = ppc_result_b & 15;
         ppc_state.ppc_sr[grab_sr] = ppc_result_d;
@@ -1237,7 +1237,7 @@ void ppc_mtsrin(){
 }
 
 void ppc_mfsr(){
-    if ((ppc_state.ppc_msr && 0x4000) == 0){
+    if ((ppc_state.ppc_msr & 0x4000) == 0){
         reg_d = (ppc_cur_instruction >> 21) & 31;
         grab_sr = (ppc_cur_instruction >> 16) & 15;
         ppc_state.ppc_gpr[reg_d] = ppc_state.ppc_sr[grab_sr];
@@ -1246,7 +1246,7 @@ void ppc_mfsr(){
 }
 
 void ppc_mfsrin(){
-    if ((ppc_state.ppc_msr && 0x4000) == 0){
+    if ((ppc_state.ppc_msr & 0x4000) == 0){
         ppc_grab_regssb();
         grab_sr = ppc_result_b & 15;
         ppc_state.ppc_gpr[reg_d] = ppc_state.ppc_sr[grab_sr];
@@ -1255,7 +1255,7 @@ void ppc_mfsrin(){
 }
 
 void ppc_mfmsr(){
-    if ((ppc_state.ppc_msr && 0x4000) == 0){
+    if ((ppc_state.ppc_msr & 0x4000) == 0){
         reg_d = (ppc_cur_instruction >> 21) & 31;
         ppc_state.ppc_gpr[reg_d] = ppc_state.ppc_msr;
         ppc_store_result_regd();
@@ -1340,14 +1340,14 @@ void ppc_mtcrf(){
     ppc_grab_regssa();
     crm = ((ppc_cur_instruction >> 12) & 255);
     //check this
-    cr_mask += ((crm && 128))? 0xF0000000 : 0x00000000;
-    cr_mask += ((crm && 64))?  0x0F000000 : 0x00000000;
-    cr_mask += ((crm && 32))?  0x00F00000 : 0x00000000;
-    cr_mask += ((crm && 16))?  0x000F0000 : 0x00000000;
-    cr_mask += ((crm && 8))?   0x0000F000 : 0x00000000;
-    cr_mask += ((crm && 4))?   0x00000F00 : 0x00000000;
-    cr_mask += ((crm && 2))?   0x000000F0 : 0x00000000;
-    cr_mask += ((crm && 1))?   0x0000000F : 0x00000000;
+    cr_mask += (crm & 128) ? 0xF0000000 : 0x00000000;
+    cr_mask += (crm &  64) ? 0x0F000000 : 0x00000000;
+    cr_mask += (crm &  32) ? 0x00F00000 : 0x00000000;
+    cr_mask += (crm &  16) ? 0x000F0000 : 0x00000000;
+    cr_mask += (crm &   8) ? 0x0000F000 : 0x00000000;
+    cr_mask += (crm &   4) ? 0x00000F00 : 0x00000000;
+    cr_mask += (crm &   2) ? 0x000000F0 : 0x00000000;
+    cr_mask += (crm &   1) ? 0x0000000F : 0x00000000;
     ppc_state.ppc_cr = (ppc_result_d & cr_mask) | (ppc_state.ppc_cr & ~(cr_mask));
 }
 
@@ -1723,11 +1723,11 @@ void ppc_tw(){
     reg_a = (ppc_cur_instruction >> 11) & 31;
     reg_b = (ppc_cur_instruction >> 16) & 31;
     ppc_to = (ppc_cur_instruction >> 21) & 31;
-    if ((((int32_t)ppc_state.ppc_gpr[reg_a] < (int32_t)ppc_state.ppc_gpr[reg_b]) & (ppc_to && 0x10)) || \
-       (((int32_t)ppc_state.ppc_gpr[reg_a] > (int32_t)ppc_state.ppc_gpr[reg_b]) & (ppc_to && 0x08)) || \
-       (((int32_t)ppc_state.ppc_gpr[reg_a] == (int32_t)ppc_state.ppc_gpr[reg_b]) & (ppc_to && 0x04)) || \
-       ((ppc_state.ppc_gpr[reg_a] < ppc_state.ppc_gpr[reg_b]) & (ppc_to && 0x02)) || \
-       ((ppc_state.ppc_gpr[reg_a] > ppc_state.ppc_gpr[reg_b]) & (ppc_to && 0x01))){
+    if ((((int32_t)ppc_state.ppc_gpr[reg_a] < (int32_t)ppc_state.ppc_gpr[reg_b]) & (ppc_to & 0x10)) || \
+       (((int32_t)ppc_state.ppc_gpr[reg_a]  > (int32_t)ppc_state.ppc_gpr[reg_b]) & (ppc_to & 0x08)) || \
+       (((int32_t)ppc_state.ppc_gpr[reg_a] == (int32_t)ppc_state.ppc_gpr[reg_b]) & (ppc_to & 0x04)) || \
+       ((ppc_state.ppc_gpr[reg_a] < ppc_state.ppc_gpr[reg_b]) & (ppc_to & 0x02)) || \
+       ((ppc_state.ppc_gpr[reg_a] > ppc_state.ppc_gpr[reg_b]) & (ppc_to & 0x01))){
         ppc_expection_handler(0x0700, 0x20000);
     }
 }
@@ -1736,11 +1736,11 @@ void ppc_twi(){
     simm = (int32_t)((int16_t)((ppc_cur_instruction) & 65535));
     reg_b = (ppc_cur_instruction >> 16) & 31;
     ppc_to = (ppc_cur_instruction >> 21) & 31;
-    if ((((int32_t)ppc_state.ppc_gpr[reg_a] < simm) & (ppc_to && 0x10)) || \
-       (((int32_t)ppc_state.ppc_gpr[reg_a] > simm) & (ppc_to && 0x08)) || \
-       (((int32_t)ppc_state.ppc_gpr[reg_a] == simm) & (ppc_to && 0x04)) || \
-       ((ppc_state.ppc_gpr[reg_a] < (uint32_t)simm) & (ppc_to && 0x02)) || \
-       ((ppc_state.ppc_gpr[reg_a] > (uint32_t)simm) & (ppc_to && 0x01))){
+    if ((((int32_t)ppc_state.ppc_gpr[reg_a] < simm) & (ppc_to & 0x10)) || \
+       (((int32_t)ppc_state.ppc_gpr[reg_a]  > simm) & (ppc_to & 0x08)) || \
+       (((int32_t)ppc_state.ppc_gpr[reg_a] == simm) & (ppc_to & 0x04)) || \
+       ((ppc_state.ppc_gpr[reg_a] < (uint32_t)simm) & (ppc_to & 0x02)) || \
+       ((ppc_state.ppc_gpr[reg_a] > (uint32_t)simm) & (ppc_to & 0x01))){
         ppc_expection_handler(0x0700, 0x20000);
     }
 }
@@ -1897,11 +1897,11 @@ void ppc_stwcx(){
     ppc_effective_address = (reg_a == 0)?ppc_result_b:(ppc_result_a + ppc_result_b);
     if (ppc_state.ppc_reserve){
         address_quickinsert_translate(ppc_effective_address, ppc_result_d, 4);
-        ppc_state.ppc_cr |= (ppc_state.ppc_spr[1] && 0x80000000)?0x30000000:0x20000000;
+        ppc_state.ppc_cr |= (ppc_state.ppc_spr[1] & 0x80000000) ? 0x30000000 : 0x20000000;
         ppc_state.ppc_reserve = false;
     }
     else{
-        ppc_state.ppc_cr |= (ppc_state.ppc_spr[1] && 0x80000000)?0x10000000:0;
+        ppc_state.ppc_cr |= (ppc_state.ppc_spr[1] & 0x80000000) ? 0x10000000 : 0;
     }
 }
 
@@ -2044,7 +2044,7 @@ void ppc_lha(){
     ppc_effective_address = (reg_a == 0)?grab_d:(uint32_t)(ppc_result_a + grab_d);
     address_quickgrab_translate(ppc_effective_address, ppc_result_d, 2);
     uint16_t go_this = (uint16_t)return_value;
-    if (go_this && 0x8000){
+    if (go_this & 0x8000){
         ppc_result_d = 0xFFFF0000 | (uint32_t)return_value;
         ppc_store_result_regd();
     }
@@ -2061,7 +2061,7 @@ void ppc_lhau(){
     ppc_effective_address = (reg_a == 0)?grab_d:(uint32_t)(ppc_result_a + grab_d);
     address_quickgrab_translate(ppc_effective_address, ppc_result_d, 2);
     uint16_t go_this = (uint16_t)return_value;
-    if (go_this && 0x8000){
+    if (go_this & 0x8000){
         ppc_result_d = 0xFFFF0000 | (uint32_t)return_value;
         ppc_store_result_regd();
     }
@@ -2079,7 +2079,7 @@ void ppc_lhaux(){
     ppc_effective_address = (reg_a == 0)?ppc_result_b:(ppc_result_a + ppc_result_b);
     address_quickgrab_translate(ppc_effective_address, ppc_result_d, 2);
     uint16_t go_this = (uint16_t)return_value;
-    if (go_this && 0x8000){
+    if (go_this & 0x8000){
         ppc_result_d = 0xFFFF0000 | (uint32_t)return_value;
         ppc_store_result_regd();
     }
@@ -2097,7 +2097,7 @@ void ppc_lhax(){
     ppc_effective_address = (reg_a == 0)?ppc_result_b:(ppc_result_a + ppc_result_b);
     address_quickgrab_translate(ppc_effective_address, ppc_result_d, 2);
     uint16_t go_this = (uint16_t)return_value;
-    if (go_this && 0x8000){
+    if (go_this & 0x8000){
         ppc_result_d = 0xFFFF0000 | (uint32_t)return_value;
         ppc_store_result_regd();
     }

--- a/viacuda.cpp
+++ b/viacuda.cpp
@@ -27,7 +27,7 @@ bool via_cuda_signal_read;
 bool via_cuda_signal_write;
 
 void via_ifr_update(){
-    if ((machine_iocontrolmem_mem[VIACUDA_IFR] && 127) && (machine_iocontrolmem_mem[VIACUDA_IER] && 127)){
+    if ((machine_iocontrolmem_mem[VIACUDA_IFR] & 127) && (machine_iocontrolmem_mem[VIACUDA_IER] & 127)){
         machine_iocontrolmem_mem[VIACUDA_IFR] |= 128;
     }
     else{


### PR DESCRIPTION
Summary:

* Makefile: 'main.c' has been corrected to 'main.cpp'
* Makefile: -std=c++11 need to be explicitly added to the compilation options to work with GCC 4.x
* Using "&&" where bitwise AND is required triggers compilation warnings when compiling with non-M$oft compilers. Fixed by the proper replacement.