### PR TITLE
Map->Array replacements.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -145,7 +145,7 @@ void ppc_tbr_update()
     }
 }
 
-void ppc_expection_handler(uint32_t exception_type, uint32_t handle_args){
+void ppc_exception_handler(uint32_t exception_type, uint32_t handle_args){
     ppc_next_instruction_address = 0x0; //used to construct a new address
     grab_exception = true;
 

--- a/ppcemumain.h
+++ b/ppcemumain.h
@@ -605,26 +605,6 @@ extern void ppc_psq_stu();
 
 extern void ppc_main_opcode();
 
-//A listing of all of the available opcodes on the PPC.
-
-static std::map<uint8_t, PPCOpcode> OpcodeGrabber =
-    {{0, &ppc_illegalop},  {1, &ppc_illegalop},  {2, &ppc_illegalop},  {3, &ppc_twi},
-     {4, &ppc_opcode4},    {5, &ppc_illegalop},  {6, &ppc_illegalop},  {7, &ppc_mulli},
-     {8, &ppc_subfic},     {9, &power_dozi},     {10, &ppc_cmpli},     {11, &ppc_cmpi},
-     {12, &ppc_addic},     {13, &ppc_addicdot},  {14, &ppc_addi},      {15, &ppc_addis},
-     {16, &ppc_opcode16},  {17, &ppc_sc},        {18, &ppc_opcode18},  {19, &ppc_opcode19},
-     {20, &ppc_rlwimi},    {21, &ppc_rlwinm},    {22, &power_rlmi},    {23, &ppc_rlwnm},
-     {24, &ppc_ori},       {25, &ppc_oris},      {26, &ppc_xori},      {27, &ppc_xoris},
-     {28, &ppc_andidot},   {29, &ppc_andisdot},  {30, &ppc_illegalop}, {31, &ppc_opcode31},
-     {32, &ppc_lwz},       {33, &ppc_lwzu},      {34, &ppc_lbz},       {35, &ppc_lbzu},
-     {36, &ppc_stw},       {37, &ppc_stwu},      {38, &ppc_stb},       {39, &ppc_stbu},
-     {40, &ppc_lhz},       {41, &ppc_lhzu},      {42, &ppc_lha},       {43, &ppc_lhau},
-     {44, &ppc_sth},       {45, &ppc_sthu},      {46, &ppc_lmw},       {47, &ppc_stmw},
-     {48, &ppc_lfs},       {49, &ppc_lfsu},      {50, &ppc_lfd},       {51, &ppc_lfdu},
-     {52, &ppc_stfs},      {53, &ppc_stfsu},     {54, &ppc_stfd},      {55, &ppc_stfdu},
-     {56, &ppc_psq_l},     {57, &ppc_psq_lu},    {58, &ppc_illegalop}, {59, &ppc_opcode59},
-     {60, &ppc_psq_st},    {61, &ppc_psq_stu},   {62, &ppc_illegalop}, {63, &ppc_opcode63}};
-
 //All of the opcodes possible are generated from the first 6 bits
 //of each instruction given by the processor.
 

--- a/ppcemumain.h
+++ b/ppcemumain.h
@@ -624,13 +624,6 @@ extern void ppc_main_opcode();
      table, partially due to instructions that use either 6 or 11 bits
      for the instruction.
      **/
-static std::map<uint8_t, PPCOpcode> SubOpcode16Grabber=
-    {{0, &ppc_bc}, {1, &ppc_bcl}, {2, &ppc_bca}, {3, &ppc_bcla}
-    };
-
-static std::map<uint8_t, PPCOpcode> SubOpcode18Grabber=
-    {{0, &ppc_b}, {1, &ppc_bl}, {2, &ppc_ba}, {3, &ppc_bla}
-    };
 
 static std::map<uint16_t, PPCOpcode> SubOpcode19Grabber=
     {{32, &ppc_bclr},    {33, &ppc_bclrl},  {66, &ppc_crnor},   {100, &ppc_rfi},

--- a/ppcemumain.h
+++ b/ppcemumain.h
@@ -217,7 +217,7 @@ void ppc_setsoov(uint32_t a, uint32_t b);
 void ppc_changecrf0(uint32_t set_result);
 
 void ppc_tbr_update();
-void ppc_expection_handler(uint32_t exception_type, uint32_t handle_args);
+void ppc_exception_handler(uint32_t exception_type, uint32_t handle_args);
 
 //MEMORY DECLARATIONS
 extern unsigned char * machine_sysram_mem;

--- a/ppcmemory.cpp
+++ b/ppcmemory.cpp
@@ -545,7 +545,7 @@ void address_quickinsert_translate(uint32_t value_insert, uint32_t address_grab,
         final_grab |= (address_grab & 0x1FFFF);
         //Check the PP Tags in the batl
         //if (!(ppc_state.ppc_spr[grab_batl] == 0x2)){
-        //    ppc_expection_handler(0x0300, 0x0);
+        //    ppc_exception_handler(0x0300, 0x0);
         // }
         address_grab = final_grab;
     }
@@ -769,7 +769,7 @@ void address_quickgrab_translate(uint32_t address_grab, uint8_t bit_num){
         final_grab |= (address_grab & 0x1FFFF);
         //Check the PP Tags in the batl
         //if ((ppc_state.ppc_spr[grab_batl] & 0x3) == 0x0){
-        //    ppc_expection_handler(0x0300, 0x0);
+        //    ppc_exception_handler(0x0300, 0x0);
         //}
         address_grab = final_grab;
     }
@@ -974,7 +974,7 @@ void quickinstruction_translate(uint32_t address_grab){
         final_grab |= (((address_grab & 0x0FFE0000) & blocklen) | (ppc_state.ppc_spr[grab_batl] & 0xFFFE0000));
         final_grab |= (address_grab & 0x1FFFF);
         //if ((ppc_state.ppc_spr[grab_batl] & 0x3) == 0x0){
-        //    ppc_expection_handler(0x0400, 0x0);
+        //    ppc_exception_handler(0x0400, 0x0);
         //}
         address_grab = final_grab;
     }

--- a/ppcopcodes.cpp
+++ b/ppcopcodes.cpp
@@ -77,6 +77,15 @@ static PPCOpcode OpcodeGrabber[] = {
     ppc_psq_st,    ppc_psq_stu,   ppc_illegalop, ppc_opcode63
 };
 
+/** Lookup tables for branch instructions. */
+static PPCOpcode SubOpcode16Grabber[] = {
+    ppc_bc, ppc_bcl, ppc_bca, ppc_bcla
+};
+
+static PPCOpcode SubOpcode18Grabber[] = {
+    ppc_b, ppc_bl, ppc_ba, ppc_bla
+};
+
 /**
 Extract the registers desired and the values of the registers
 This also takes the MSR into account, mainly to determine
@@ -243,23 +252,11 @@ void ppc_opcode4(){
 }
 
 void ppc_opcode16(){
-    uint8_t subop_grab = ppc_cur_instruction & 3;
-
-    #ifdef EXHAUSTIVE_DEBUG
-    uint32_t regrab = (uint32_t)subop_grab;
-    printf("Executing Opcode 16 table subopcode entry %d \n", regrab);
-    SubOpcode16Grabber[subop_grab]();
-    #else
-    SubOpcode16Grabber[subop_grab]();
-    #endif // EXHAUSTIVE_DEBUG
+    SubOpcode16Grabber[ppc_cur_instruction & 3]();
 }
 
 void ppc_opcode18(){
-    uint8_t subop_grab = ppc_cur_instruction & 3;
-    //printf("Reading from Opcode 18 table \n");
-    //uint32_t regrab = (uint32_t)subop_grab;
-    //printf("Executing subopcode entry %d \n", regrab);
-    SubOpcode18Grabber[subop_grab]();
+    SubOpcode18Grabber[ppc_cur_instruction & 3]();
 }
 
 void ppc_opcode19(){

--- a/ppcopcodes.cpp
+++ b/ppcopcodes.cpp
@@ -206,7 +206,7 @@ void ppc_illegalop(){
     uint32_t grab_it = (uint32_t) illegal_code;
     printf("Illegal opcode reported: %d Report this! \n", grab_it);
     exit(-1);
-    //ppc_expection_handler(0x0700, 0x80000);
+    //ppc_exception_handler(0x0700, 0x80000);
 }
 
 void ppc_illegalsubop31(){
@@ -253,7 +253,7 @@ void ppc_opcode19(){
     }
     else{
         std::cout << "ILLEGAL SUBOPCODE: " << subop_grab << std::endl;
-        ppc_expection_handler(0x0700, 0x80000);
+        ppc_exception_handler(0x0700, 0x80000);
     }
     #else
     SubOpcode19Grabber[subop_grab]();
@@ -270,7 +270,7 @@ void ppc_opcode31(){
     }
     else{
         std::cout << "ILLEGAL SUBOPCODE: " << subop_grab << std::endl;
-        ppc_expection_handler(0x0700, 0x80000);
+        ppc_exception_handler(0x0700, 0x80000);
     }
     #else
     SubOpcode31Grabber[subop_grab]();
@@ -287,7 +287,7 @@ void ppc_opcode59(){
     }
     else{
         std::cout << "ILLEGAL SUBOPCODE: " << subop_grab << std::endl;
-        ppc_expection_handler(0x0700, 0x80000);
+        ppc_exception_handler(0x0700, 0x80000);
     }
     #else
     SubOpcode59Grabber[subop_grab]();
@@ -304,7 +304,7 @@ void ppc_opcode63(){
     }
     else{
         std::cout << "ILLEGAL SUBOPCODE: " << subop_grab << std::endl;
-        ppc_expection_handler(0x0700, 0x80000);
+        ppc_exception_handler(0x0700, 0x80000);
     }
     #else
     SubOpcode63Grabber[subop_grab]();
@@ -1841,7 +1841,7 @@ void ppc_rfi(){
 }
 
 void ppc_sc(){
-    ppc_expection_handler(0x0C00, 0x20000);
+    ppc_exception_handler(0x0C00, 0x20000);
 }
 
 void ppc_tw(){
@@ -1853,7 +1853,7 @@ void ppc_tw(){
        (((int32_t)ppc_state.ppc_gpr[reg_a] == (int32_t)ppc_state.ppc_gpr[reg_b]) & (ppc_to & 0x04)) || \
        ((ppc_state.ppc_gpr[reg_a] < ppc_state.ppc_gpr[reg_b]) & (ppc_to & 0x02)) || \
        ((ppc_state.ppc_gpr[reg_a] > ppc_state.ppc_gpr[reg_b]) & (ppc_to & 0x01))){
-        ppc_expection_handler(0x0700, 0x20000);
+        ppc_exception_handler(0x0700, 0x20000);
     }
 }
 
@@ -1866,7 +1866,7 @@ void ppc_twi(){
        (((int32_t)ppc_state.ppc_gpr[reg_a] == simm) & (ppc_to & 0x04)) || \
        ((ppc_state.ppc_gpr[reg_a] < (uint32_t)simm) & (ppc_to & 0x02)) || \
        ((ppc_state.ppc_gpr[reg_a] > (uint32_t)simm) & (ppc_to & 0x01))){
-        ppc_expection_handler(0x0700, 0x20000);
+        ppc_exception_handler(0x0700, 0x20000);
     }
 }
 
@@ -1924,7 +1924,7 @@ void ppc_dcbz(){
         address_quickinsert_translate(0, (ppc_effective_address + 28), 4);
     }
     else{
-        ppc_expection_handler(0x0600, 0x00000);
+        ppc_exception_handler(0x0600, 0x00000);
     }
 }
 
@@ -1962,7 +1962,7 @@ void ppc_stbux(){
         address_quickinsert_translate(ppc_result_d, ppc_effective_address, 1);
     }
     else{
-        ppc_expection_handler(0x07000, 0x20000);
+        ppc_exception_handler(0x07000, 0x20000);
     }
     ppc_result_a = ppc_effective_address;
     ppc_store_result_rega();
@@ -2087,7 +2087,7 @@ void ppc_lbzu(){
         ppc_effective_address = ppc_result_a + grab_d;
     }
     else{
-        ppc_expection_handler(0x0700, 0x20000);
+        ppc_exception_handler(0x0700, 0x20000);
     }
     address_quickgrab_translate(ppc_effective_address, 1);
     ppc_result_d = return_value;
@@ -2112,7 +2112,7 @@ void ppc_lbzux(){
         ppc_effective_address = ppc_result_a + ppc_result_b;
     }
     else{
-        ppc_expection_handler(0x0700, 0x20000);
+        ppc_exception_handler(0x0700, 0x20000);
     }
     address_quickgrab_translate(ppc_effective_address, 1);
     ppc_result_d = return_value;
@@ -2271,7 +2271,7 @@ void ppc_lwzu(){
         ppc_effective_address = ppc_result_a + grab_d;
     }
     else{
-        ppc_expection_handler(0x0700, 0x20000);
+        ppc_exception_handler(0x0700, 0x20000);
     }
     address_quickgrab_translate(ppc_effective_address, 4);
     ppc_result_d = return_value;
@@ -2296,7 +2296,7 @@ void ppc_lwzux(){
         ppc_effective_address = ppc_result_a + ppc_result_b;
     }
     else{
-        ppc_expection_handler(0x0700, 0x20000);
+        ppc_exception_handler(0x0700, 0x20000);
     }
     address_quickgrab_translate(ppc_effective_address, 4);
     ppc_result_d = return_value;
@@ -2385,10 +2385,10 @@ void ppc_lswx(){
     ppc_grab_regsdab();
     //Invalid instruction forms
     if ((ppc_result_d == 0) && (ppc_result_a == 0)){
-        ppc_expection_handler(0x0700, 0x100000);
+        ppc_exception_handler(0x0700, 0x100000);
     }
     if ((ppc_result_d == ppc_result_a) || (ppc_result_a == ppc_result_b)){
-        ppc_expection_handler(0x0700, 0x100000);
+        ppc_exception_handler(0x0700, 0x100000);
     }
     ppc_effective_address = (reg_a == 0)?ppc_result_b:(ppc_result_a + ppc_result_b);
     grab_inb = ppc_state.ppc_spr[1] & 127;

--- a/ppcopcodes.cpp
+++ b/ppcopcodes.cpp
@@ -58,6 +58,25 @@
 
  uint32_t strwrd_replace_value;
 
+/** Lookup tables. */
+
+/** Primary opcode (bits 0...5) lookup table. */
+static PPCOpcode OpcodeGrabber[] = {
+    ppc_illegalop, ppc_illegalop, ppc_illegalop, ppc_twi,       ppc_opcode4,
+    ppc_illegalop, ppc_illegalop, ppc_mulli,     ppc_subfic,    power_dozi,
+    ppc_cmpli,     ppc_cmpi,      ppc_addic,     ppc_addicdot,  ppc_addi,
+    ppc_addis,     ppc_opcode16,  ppc_sc,        ppc_opcode18,  ppc_opcode19,
+    ppc_rlwimi,    ppc_rlwinm,    power_rlmi,    ppc_rlwnm,     ppc_ori,
+    ppc_oris,      ppc_xori,      ppc_xoris,     ppc_andidot,   ppc_andisdot,
+    ppc_illegalop, ppc_opcode31,  ppc_lwz,       ppc_lwzu,      ppc_lbz,
+    ppc_lbzu,      ppc_stw,       ppc_stwu,      ppc_stb,       ppc_stbu,
+    ppc_lhz,       ppc_lhzu,      ppc_lha,       ppc_lhau,      ppc_sth,
+    ppc_sthu,      ppc_lmw,       ppc_stmw,      ppc_lfs,       ppc_lfsu,
+    ppc_lfd,       ppc_lfdu,      ppc_stfs,      ppc_stfsu,     ppc_stfd,
+    ppc_stfdu,     ppc_psq_l,     ppc_psq_lu,    ppc_illegalop, ppc_illegalop,
+    ppc_psq_st,    ppc_psq_stu,   ppc_illegalop, ppc_opcode63
+};
+
 /**
 Extract the registers desired and the values of the registers
 This also takes the MSR into account, mainly to determine


### PR DESCRIPTION
As the title says, I replaced three maps with arrays of function pointers. They all are now resided in the source file where they are used. Keeping static tables in header files should be avoided.