### PR TITLE
Fix build on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ dingusppc.exe
 # Ignore system files
 .DS_Store
 Thumb.db
+
+# IDE ignores
+build
+build-*
+*.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(dingusppc "${PROJECT_SOURCE_DIR}/thirdparty/SDL2/lib/x64/S
                                 "${PROJECT_SOURCE_DIR}/thirdparty/SDL2/lib/x64/SDL2main.lib"
                                 libsoundio_static ${LIBSOUNDIO_LIBS})
 else()
-target_link_libraries(dingusppc libsoundio_static ${LIBSOUNDIO_LIBS} ${SDL2_LIBRARIES})
+target_link_libraries(dingusppc libsoundio_static ${LIBSOUNDIO_LIBS} ${SDL2_LIBRARIES} ${CMAKE_DL_LIBS})
 endif()
 
 
@@ -68,7 +68,7 @@ target_link_libraries(testppc "${PROJECT_SOURCE_DIR}/thirdparty/SDL2/lib/x64/SDL
                               "${PROJECT_SOURCE_DIR}/thirdparty/SDL2/lib/x64/SDL2main.lib"
                               libsoundio_static ${LIBSOUNDIO_LIBS})
 else()
-target_link_libraries(testppc libsoundio_static ${LIBSOUNDIO_LIBS} ${SDL2_LIBRARIES})
+target_link_libraries(testppc libsoundio_static ${LIBSOUNDIO_LIBS} ${SDL2_LIBRARIES} ${CMAKE_DL_LIBS})
 endif()
 
 add_custom_command(

--- a/devices/dbdma.cpp
+++ b/devices/dbdma.cpp
@@ -21,11 +21,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /** @file Descriptor-based direct memory access emulation. */
 
-#include <cinttypes>
-#include <thirdparty/loguru/loguru.hpp>
 #include "dbdma.h"
-#include "endianswap.h"
 #include "cpu/ppc/ppcmmu.h"
+#include "endianswap.h"
+#include <cinttypes>
+#include <cstring>
+#include <thirdparty/loguru/loguru.hpp>
 
 void DMAChannel::get_next_cmd(uint32_t cmd_addr, DMACmd *p_cmd)
 {

--- a/devices/i2c.h
+++ b/devices/i2c.h
@@ -27,9 +27,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef I2C_H
 #define I2C_H
 
-#include <thirdparty/loguru/loguru.hpp>
-#include <string>
+#include <cstring>
 #include <stdexcept>
+#include <string>
+#include <thirdparty/loguru/loguru.hpp>
 
 /** Base class for I2C devices */
 class I2CDevice {


### PR DESCRIPTION
- Fix missing includes for `std::memcpy` and `std::memset` in `devices/dbdma.cpp` and `devices/i2c.h` on linux.
- Fix build due to `libdl` not being linked.

Note: `libsoundio` is building and linking fine without any changes on linux