### PR TITLE
RTC and TBR fixes

### DIFF
--- a/core/mathutils.h
+++ b/core/mathutils.h
@@ -1,0 +1,49 @@
+/*
+DingusPPC - The Experimental PowerPC Macintosh emulator
+Copyright (C) 2018-22 divingkatae and maximum
+                      (theweirdo)     spatium
+
+(Contact divingkatae#1017 or powermax#2286 on Discord for more info)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MATH_UTILS_H
+#define MATH_UTILS_H
+
+inline void _u32xu64(uint32_t a, uint64_t b, uint32_t &hi, uint64_t &lo)
+{
+    uint64_t p0 = (b & 0xffffffff) * a;
+    uint64_t p1 = (b >> 32) * a;
+    lo = p0 + (p1 << 32);
+    hi = (p1 >> 32) + (lo < p0);
+}
+
+inline void _u32xu64(uint32_t a, uint64_t b, uint64_t &hi, uint32_t &lo)
+{
+    uint64_t p0 = (b & 0xffffffff) * a;
+    uint64_t p1 = (b >> 32) * a;
+    lo = p0;
+    hi = (p0 >> 32) + p1;
+}
+
+inline void _u64xu64(uint64_t a, uint64_t b, uint64_t &hi, uint64_t &lo)
+{
+    uint32_t p0h; uint64_t p0l; _u32xu64(b, a, p0h, p0l);
+    uint64_t p1h; uint32_t p1l; _u32xu64(b >> 32, a, p1h, p1l);
+    lo = p0l + ((uint64_t)p1l << 32);
+    hi = p0h + p1h + (lo < p0l);
+}
+
+#endif // MATH_UTILS_H

--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -159,6 +159,7 @@ extern uint32_t opcode_value;      // used for interpreting opcodes
 
 extern uint64_t timebase_counter;
 extern uint64_t tbr_wr_timestamp;
+extern uint64_t rtc_timestamp;
 extern uint64_t tbr_wr_value;
 extern uint64_t tbr_freq_hz;
 extern uint32_t rtc_lo, rtc_hi;

--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -161,7 +161,7 @@ extern uint64_t timebase_counter;
 extern uint64_t tbr_wr_timestamp;
 extern uint64_t rtc_timestamp;
 extern uint64_t tbr_wr_value;
-extern uint64_t tbr_freq_hz;
+extern uint32_t tbr_freq_ghz;
 extern uint32_t rtc_lo, rtc_hi;
 
 // Additional steps to prevent overflow?

--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -69,7 +69,7 @@ int      icnt_factor;
 uint64_t tbr_wr_timestamp;  // stores vCPU virtual time of the last TBR write
 uint64_t rtc_timestamp;     // stores vCPU virtual time of the last RTC write
 uint64_t tbr_wr_value;      // last value written to the TBR
-uint64_t tbr_freq_hz;       // TBR/RTC driving frequency in Hz
+uint32_t tbr_freq_ghz;      // TBR/RTC driving frequency in GHz expressed as a 32 bit fraction less than 1.0.
 uint64_t timebase_counter;  // internal timebase counter
 uint32_t decr;              // current value of PPC DEC register
 uint32_t rtc_lo;            // MPC601 RTC lower, counts nanoseconds
@@ -766,7 +766,7 @@ void ppc_cpu_init(MemCtrlBase* mem_ctrl, uint32_t cpu_version, uint64_t tb_freq)
     tbr_wr_timestamp = 0;
     rtc_timestamp = 0;
     tbr_wr_value = 0;
-    tbr_freq_hz = tb_freq;
+    tbr_freq_ghz = (tb_freq << 32) / NS_PER_SEC;
 
     exec_flags = 0;
 

--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -66,7 +66,8 @@ uint64_t g_icycles;
 int      icnt_factor;
 
 /* global variables related to the timebase facility */
-uint64_t tbr_wr_timestamp;  // stores vCPU virtual time of the last TBR/RTC write
+uint64_t tbr_wr_timestamp;  // stores vCPU virtual time of the last TBR write
+uint64_t rtc_timestamp;     // stores vCPU virtual time of the last RTC write
 uint64_t tbr_wr_value;      // last value written to the TBR
 uint64_t tbr_freq_hz;       // TBR/RTC driving frequency in Hz
 uint64_t timebase_counter;  // internal timebase counter
@@ -763,6 +764,7 @@ void ppc_cpu_init(MemCtrlBase* mem_ctrl, uint32_t cpu_version, uint64_t tb_freq)
     g_icycles   = 0;
     icnt_factor = 4;
     tbr_wr_timestamp = 0;
+    rtc_timestamp = 0;
     tbr_wr_value = 0;
     tbr_freq_hz = tb_freq;
 

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -858,9 +858,7 @@ void dppc_interpreter::ppc_mtmsr() {
 static inline void calc_rtcl_value()
 {
     uint64_t new_ts = get_virt_time_ns();
-    uint64_t diff    = new_ts - rtc_timestamp;
-    uint64_t rtc_inc = diff * tbr_freq_hz / NS_PER_SEC;
-    uint64_t rtc_l   = rtc_lo + (rtc_inc << 7);
+    uint64_t rtc_l = new_ts - rtc_timestamp + rtc_lo;
     if (rtc_l >= ONE_BILLION_NS) { // check RTCL overflow
         rtc_hi += rtc_l / ONE_BILLION_NS;
         rtc_lo  = rtc_l % ONE_BILLION_NS;

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -930,12 +930,12 @@ void dppc_interpreter::ppc_mtspr() {
 
     switch (ref_spr) {
     case SPR::RTCL_S:
+        calc_rtcl_value();
         rtc_lo = val & 0x3FFFFF80UL;
-        rtc_timestamp = get_virt_time_ns();
         break;
     case SPR::RTCU_S:
+        calc_rtcl_value();
         rtc_hi = val;
-        rtc_timestamp = get_virt_time_ns();
         break;
     case SPR::TBL_S:
         update_timebase(0xFFFFFFFF00000000ULL, val);

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -883,7 +883,7 @@ void dppc_interpreter::ppc_mfspr() {
         ppc_state.spr[SPR::RTCL_U] = calc_rtcl_value();
         break;
     case SPR::RTCU_U:
-        ppc_state.spr[SPR::RTCL_U] = rtc_hi;
+        ppc_state.spr[SPR::RTCU_U] = rtc_hi;
         break;
     }
 

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -857,13 +857,13 @@ void dppc_interpreter::ppc_mtmsr() {
 
 static inline uint64_t calc_rtcl_value()
 {
-    uint64_t diff    = get_virt_time_ns() - tbr_wr_timestamp;
+    uint64_t diff    = get_virt_time_ns() - rtc_timestamp;
     uint64_t rtc_inc = diff * tbr_freq_hz / NS_PER_SEC;
     uint64_t rtc_l   = rtc_lo + (rtc_inc << 7);
     if (rtc_l >= ONE_BILLION_NS) { // check RTCL overflow
         rtc_hi += rtc_l / ONE_BILLION_NS;
         rtc_lo  = rtc_l % ONE_BILLION_NS;
-        tbr_wr_timestamp = get_virt_time_ns();
+        rtc_timestamp = get_virt_time_ns();
         rtc_l =  rtc_lo;
     }
     return rtc_l & 0x3FFFFF80UL;
@@ -927,11 +927,11 @@ void dppc_interpreter::ppc_mtspr() {
     switch (ref_spr) {
     case SPR::RTCL_S:
         rtc_lo = val & 0x3FFFFF80UL;
-        tbr_wr_timestamp = get_virt_time_ns();
+        rtc_timestamp = get_virt_time_ns();
         break;
     case SPR::RTCU_S:
         rtc_hi = val;
-        tbr_wr_timestamp = get_virt_time_ns();
+        rtc_timestamp = get_virt_time_ns();
         break;
     case SPR::TBL_S:
         update_timebase(0xFFFFFFFF00000000ULL, val);

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // General opcodes for the processor - ppcopcodes.cpp
 
 #include <core/timermanager.h>
+#include <core/mathutils.h>
 #include "ppcemu.h"
 #include "ppcmmu.h"
 #include <array>
@@ -895,7 +896,7 @@ void dppc_interpreter::ppc_mfspr() {
 static inline uint64_t calc_tbr_value()
 {
     uint64_t diff = get_virt_time_ns() - tbr_wr_timestamp;
-    uint64_t tbr_inc = diff * tbr_freq_hz / NS_PER_SEC;
+    uint64_t tbr_inc; uint32_t tbr_inc_lo; _u32xu64(tbr_freq_ghz, diff, tbr_inc, tbr_inc_lo);
     return (tbr_wr_value + tbr_inc);
 }
 


### PR DESCRIPTION
1)
Fixed a typo that caused rtc@ to always return 0 for the upper 32 bits (represents seconds). The problem could cause the following to hang on Power Mac 7500:

`cr 2000 0 do get-msecs u. 1 ms loop`

2)
Fixed an issue where the following would cause inconsistent results (tb in the left column would sometimes decrement instead of increment):
```
: tbrtctest
2 0 do
	2 0 do
		cr tb@ 8 u.r ." ." 8 u.r
	loop
	2 0 do
		cr 12 spaces rtc@ 8 u.r ." ." 8 u.r
	loop
	2 0 do
		cr tb@ 8 u.r ." ." 8 u.r space
		rtc@ 8 u.r ." ." 8 u.r
	loop
loop
;
tbrtctest
```
RTC and TBR could not be used simultaneously because they are both incremented by an amount based on the last time stamp but that time stamp can be changed by accessing either RTC or TBR. The solution is to have a different time stamp for each.

3)
Fixed an issue where TBR and RTC don't have full 64-bit range. The original calculation was 64 bit and ended with a ÷ 1000000000. This means the max for the upper 32 bits is 2^32/10^9 = 4. The problem is worse for TBR than RTC because the RTC timestamp is changed whenever RTC is read. For TBR, the timestamp is updated only when TBR is written. But the problem still exists for RTC when it hasn't been accessed for a long time.

The solution is to use a multiplication method that supports a 96 bit product. I added a couple routines for that. GCC/clang have 128 bit integer calculations but I don't know if that's portable for Windows. Another option is to use floating point, but you need a floating point type with at least 64 bits of mantissa. long double should work if this assertion is true:
	`assert ((uint64_t)((long double)0x1000000000000001) == 0x1000000000000001);`

The following can calculate mantissa sizes:
```
	#define findmantissasize(t) do { int i = 1; t x = 1; while (x > (t)(x - 1)) { x = x * 2 + 1; i++; }; printf("%s:%d\n", #t, i - 1); } while (0)
	findmantissasize(float);
	findmantissasize(double);
	findmantissasize(long double);

float:24
double:53
long double:64
```

TBR driving frequency is assumed to be less than 1 GHz. Some minor modification is required for > 1 GHz support.

4)
Fixed an issue where get-msecs-601 and get-msecs-60x were not returning the same value. RTC was being calculated using timebase frequency instead of nanosecond frequency. 601 uses RTC. 60x uses TBR. On a real Mac, a G3 CPU won't have a RTC and would cause an exception. This is not the case for dingusppc but I don't think that's a problem.

The new implementation keeps all bits of rtc_lo so that it can be incremented correctly. It's only during reading or setting the rtc_L SPR that the 7 least significant bits are masked.

5)
Fixed an issue where RTC was not being updated if only the upper 32 bits was read.

6)
Fixed an issue where setting RTC upper or lower doesn't adjust the other.