### PR TITLE
Fix PCI struct offset size

### DIFF
--- a/devices/common/pci/pcidevice.cpp
+++ b/devices/common/pci/pcidevice.cpp
@@ -190,7 +190,7 @@ int PCIDevice::attach_exp_rom_image(const std::string img_path)
         uint32_t exp_rom_image_size = img_file.tellg();
 
         // verify PCI struct offset
-        uint32_t pci_struct_offset = 0;
+        uint16_t pci_struct_offset = 0;
         img_file.seekg(0x18, std::ios::beg);
         img_file.read((char *)&pci_struct_offset, sizeof(pci_struct_offset));
 


### PR DESCRIPTION
The Pointer to PCI Data Structure is supposed to be two bytes. It is described in the PCI Firmware Specification Revision 3.0, section 5.1.1. PCI Expansion ROM Header Format. The pointer is two bytes at 0x18. The pointer is supposed to be a multiple of 4 which means there's always at least two bytes of padding after the pointer. Some BIOS firmware images may use the 2 bytes following the pointer for other purposes (plus additional bytes before the PCI Data Structure) so we cannot assume the bytes will be zero. Some PCI expansion ROMs may include both BIOS and Open Firmware images.