### PR TITLE
Fix PCI config r/w of byte and word and unaligned.

### DIFF
--- a/devices/common/pci/pcihost.cpp
+++ b/devices/common/pci/pcihost.cpp
@@ -83,3 +83,8 @@ void PCIHost::attach_pci_device(std::string& dev_name, int slot_id)
     this->pci_register_device(
         slot_id, dynamic_cast<PCIDevice*>(gMachineObj->get_comp_by_name(dev_name)));
 }
+
+PCIDevice *PCIHost::pci_find_device(uint8_t bus_num, uint8_t dev_num, uint8_t fun_num)
+{
+    return NULL;
+}

--- a/devices/common/pci/pcihost.h
+++ b/devices/common/pci/pcihost.h
@@ -29,6 +29,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <unordered_map>
 #include <vector>
 
+enum {
+    PCI_CONFIG_DIRECTION    = 1,
+    PCI_CONFIG_READ         = 0,
+    PCI_CONFIG_WRITE        = 1,
+
+    PCI_CONFIG_TYPE         = 4,
+    PCI_CONFIG_TYPE_0       = 0,
+    PCI_CONFIG_TYPE_1       = 4,
+};
+
+/** PCI config space access details */
+typedef struct AccessDetails {
+    uint8_t size;
+    uint8_t offset;
+    uint8_t flags;
+} AccessDetails;
+
 class PCIDevice;    // forward declaration to prevent errors
 
 class PCIHost {
@@ -45,6 +62,8 @@ public:
     virtual bool pci_unregister_mmio_region(uint32_t start_addr, uint32_t size, PCIDevice* obj);
 
     virtual void attach_pci_device(std::string& dev_name, int slot_id);
+
+    virtual PCIDevice *pci_find_device(uint8_t bus_num, uint8_t dev_num, uint8_t fun_num);
 
 protected:
     std::unordered_map<int, PCIDevice*> dev_map;

--- a/devices/memctrl/mpc106.h
+++ b/devices/memctrl/mpc106.h
@@ -59,12 +59,13 @@ public:
 
 protected:
     /* PCI access */
-    uint32_t pci_read(uint32_t size);
-    void pci_write(uint32_t value, uint32_t size);
+    uint32_t pci_read(uint32_t offset, uint32_t size);
+    void pci_write(uint32_t offset, uint32_t value, uint32_t size);
+    void cfg_setup(uint32_t offset, int size, int &bus_num, int &dev_num, int &fun_num, uint8_t &reg_offs, AccessDetails &details, PCIDevice *&device);
 
     /* my own PCI configuration registers access */
-    uint32_t pci_cfg_read(uint32_t reg_offs, uint32_t size);
-    void pci_cfg_write(uint32_t reg_offs, uint32_t value, uint32_t size);
+    uint32_t pci_cfg_read(uint32_t reg_offs, AccessDetails &details);
+    void pci_cfg_write(uint32_t reg_offs, uint32_t value, AccessDetails &details);
 
     bool supports_io_space(void) {
         return true;

--- a/devices/video/atirage.cpp
+++ b/devices/video/atirage.cpp
@@ -161,34 +161,35 @@ void ATIRage::notify_bar_change(int bar_num)
     }
 }
 
-uint32_t ATIRage::pci_cfg_read(uint32_t reg_offs, uint32_t size)
+uint32_t ATIRage::pci_cfg_read(uint32_t reg_offs, AccessDetails &details)
 {
     if (reg_offs < 64) {
-        return PCIDevice::pci_cfg_read(reg_offs, size);
+        return PCIDevice::pci_cfg_read(reg_offs, details);
     }
 
     switch (reg_offs) {
     case 0x40:
         return this->user_cfg;
     default:
-        LOG_F(WARNING, "ATIRage: reading from unimplemented config register at 0x%X", reg_offs);
+        LOG_READ_UNIMPLEMENTED_CONFIG_REGISTER();
     }
 
     return 0;
 }
 
-void ATIRage::pci_cfg_write(uint32_t reg_offs, uint32_t value, uint32_t size)
+void ATIRage::pci_cfg_write(uint32_t reg_offs, uint32_t value, AccessDetails &details)
 {
     if (reg_offs < 64) {
-        PCIDevice::pci_cfg_write(reg_offs, value, size);
-    } else {
-        switch (reg_offs) {
-        case 0x40:
-            this->user_cfg = value;
-            break;
-        default:
-            LOG_F(WARNING, "ATIRage: writing to unimplemented config register at 0x%X", reg_offs);
-        }
+        PCIDevice::pci_cfg_write(reg_offs, value, details);
+        return;
+    }
+
+    switch (reg_offs) {
+    case 0x40:
+        this->user_cfg = value;
+        break;
+    default:
+        LOG_WRITE_UNIMPLEMENTED_CONFIG_REGISTER();
     }
 }
 

--- a/devices/video/atirage.h
+++ b/devices/video/atirage.h
@@ -64,8 +64,8 @@ public:
         return true;
     };
 
-    uint32_t pci_cfg_read(uint32_t reg_offs, uint32_t size);
-    void pci_cfg_write(uint32_t reg_offs, uint32_t value, uint32_t size);
+    uint32_t pci_cfg_read(uint32_t reg_offs, AccessDetails &details);
+    void pci_cfg_write(uint32_t reg_offs, uint32_t value, AccessDetails &details);
 
     /* I/O space access methods */
     bool pci_io_read(uint32_t offset, uint32_t size, uint32_t* res);


### PR DESCRIPTION
dingusppc could not read bytes from offset 1,2,3 or words from offset 2. dingusppc did not read words from offset 1,3 and longs from offset 1,2,3 in the same way as a real Power Mac 8600 or B&W G3. This commit fixes those issues.

- Added pci_cfg_rev_read. It takes a 32 bit value from offset 0 and returns a value of the specified size using bytes starting from the specified offset. Offsets 4,5, & 6 wrap around to 0,1, & 2 respectively. The result bytes are in flipped order as required by the read method (so a value of 0x12345678 is returned as 0x78563412) A real Power Mac 8600 might return a random byte for offset 4, 5, 6 for vci0 but usually not for pci1. A B&W G3 seems to always wrap around correctly. We won't read random bytes, and we won't read a default such as 00 or FF. We'll do the wrap around which makes the most sense because writing 0x12345678 to any offset and reading from the same offset should produce the value that was written.

- Added pci_cfg_rev_write. It takes a 32 bit value from offset 0, and modifies a specified number of bytes starting at a specified offset with the offset wrapping around to 0 if it exceeds 3. The modified bytes take their new values from the flipped bytes passed to pci_cfg_write. When size is 4, the original value is not used since all bytes will be modified.

Basically, those two functions handle all the sizes and all the offsets and replace calls to BYTESWAP_32, read_mem or read_mem_rev, and write_mem or write_mem_rev. read_mem_rev, as it was used by pcidevice and some other places, could read beyond offset 3 if it were ever passed a reg_offs value that did not have offset as 0. Since the offset was always zero, it would always read the wrong byte or word if they were not at offset 0. Same for read_mem as used by mpc106. write_mem_rev, as it was used by pcidevice and some other places, could write beyond offset 3 if it were ever passed a reg_offs value that did not have offset as 0. Since the offset was always zero, it would always write the wrong byte or word if they were not at offset 0. Same for write_mem as used by mpc106.

pcidevice:
- The logging macros should be used to handle all config register access logging.
- Unaligned PCI config register accesses will be output as ERROR instead of WARNING.
- The logging macros include the offset and size. They also include the value for named registers or for writes.
- Added MMIODevice read and write methods so that PCIDevice is not abstract if a PCIDevice doesn't override the read and write method since some PCIDevices don't have MMIO.

pcihost:
- Added pci_find_device stub for handling PCI bridges in future commit.

bandit and mpc106:
- PCI host controllers will handle all PCI config access alignment and sizing. A PCIDevice will always access config registers as 32 bits on a 4 byte boundary. The AccessDetails passed to a PCIDevice config read or write method is there only for logging purposes.

bandit:
- Common MMIO code is moved to new BanditHost class so both Bandit and Chaos can use it. PCI related code is moved to new BanditPCI class.
- Simplify IDSEL to/from PCI device number conversion by removing the shift or subtract.
- Remove BANDIT_ID_SEL check. The IDSEL conversion to PCI device number can find the bandit PCI device.
- For logging, make best guess of PCI device number from invalid IDSEL - the result is always reasonable for device 0x00 to 0x0A when accessing config register 0x00 (as one would do when scanning for PCI devices like lspci does).

mpc106:
- Common config space code is put in cfg_setup. It handles extracting the offset.
- Added code to log access to unimplemented config registers of grackle.
- Don't call setup_ram when writing to config registers that setup_ram doesn't use.
- pci_cfg_read calls READ_DWORD_LE_A and pci_cfg_write calls WRITE_DWORD_LE_A. When reading or writing memory that is organized as little endian dwords, such as my_pci_cfg_hdr of mpc106, the function should explicitly state that it's little endian so that the emulator may be ported one day to a CPU architecture that is not little endian.

atirage:
- The changes correctly place user_cfg at byte 0x40 instead of 0x43 and writes the correct byte depending on size and offset.