### PR TITLE
64 bit BAR support

### DIFF
--- a/devices/common/pci/bandit.h
+++ b/devices/common/pci/bandit.h
@@ -49,10 +49,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define BANDIT_CAR_TYPE     (1 << 0)   // Bandit config address type bit
 
 /* Convenient macros for parsing CONFIG_ADDR fields. */
-#define BUS_NUM()   (this->config_addr >> 16) & 0xFFU
-#define DEV_NUM()   (this->config_addr >> 11) & 0x1FU
-#define FUN_NUM()   (this->config_addr >>  8) & 0x07U
-#define REG_NUM()   (this->config_addr      ) & 0xFCU
+#define BUS_NUM()   ((this->config_addr >> 16) & 0xFFU)
+#define DEV_NUM()   ((this->config_addr >> 11) & 0x1FU)
+#define FUN_NUM()   ((this->config_addr >>  8) & 0x07U)
+#define REG_NUM()   ((this->config_addr      ) & 0xFCU)
 
 /** Bandit specific configuration registers. */
 enum {

--- a/devices/common/pci/pcidevice.h
+++ b/devices/common/pci/pcidevice.h
@@ -58,6 +58,16 @@ enum {
     PCI_VENDOR_NVIDIA   = 0x10DE,
 };
 
+/** PCI BAR types */
+enum PCIBarType {
+    BAR_Unused,
+    BAR_IO_16Bit,
+    BAR_IO_32Bit,
+    BAR_MEM_20Bit, // < 1M
+    BAR_MEM_32Bit,
+    BAR_MEM_64Bit,
+    BAR_MEM_64BitHi,
+};
 
 class PCIDevice : public MMIODevice {
 public:
@@ -108,6 +118,7 @@ public:
 protected:
     void do_bar_sizing(int bar_num);
     void set_bar_value(int bar_num, uint32_t value);
+    void finish_config_bars();
     void map_exp_rom_mem();
 
     std::string pci_name;      // human-readable device name
@@ -132,6 +143,7 @@ protected:
 
     uint32_t    bars[6] = { 0 };     // base address registers
     uint32_t    bars_cfg[6] = { 0 }; // configuration values for base address registers
+    PCIBarType  bars_typ[6] = { BAR_Unused }; // types for base address registers
 
     uint32_t    exp_bar_cfg  = 0;    // expansion ROM configuration
     uint32_t    exp_rom_bar  = 0;    // expansion ROM base address register

--- a/devices/ioctrl/grandcentral.cpp
+++ b/devices/ioctrl/grandcentral.cpp
@@ -43,6 +43,7 @@ GrandCentral::GrandCentral() : PCIDevice("mac-io/grandcentral"), InterruptCtrl()
     this->class_rev   = 0xFF000002;
     this->cache_ln_sz = 8;
     this->bars_cfg[0] = 0xFFFE0000UL; // declare 128Kb of memory-mapped I/O space
+    this->finish_config_bars();
 
     this->pci_notify_bar_change = [this](int bar_num) {
         this->notify_bar_change(bar_num);

--- a/devices/ioctrl/heathrow.cpp
+++ b/devices/ioctrl/heathrow.cpp
@@ -55,6 +55,7 @@ HeathrowIC::HeathrowIC() : PCIDevice("mac-io/heathrow"), InterruptCtrl()
     this->cache_ln_sz = 8;
     this->lat_timer   = 0x40;
     this->bars_cfg[0] = 0xFFF80000UL; // declare 512Kb of memory-mapped I/O space
+    this->finish_config_bars();
 
     this->pci_notify_bar_change = [this](int bar_num) {
         this->notify_bar_change(bar_num);

--- a/devices/ioctrl/ohare.cpp
+++ b/devices/ioctrl/ohare.cpp
@@ -37,6 +37,7 @@ OHare::OHare() : PCIDevice("mac-io/ohare"), InterruptCtrl()
     this->class_rev   = 0xFF000001;
     this->cache_ln_sz = 8;
     this->bars_cfg[0] = 0xFFF80000UL; // declare 512Kb of memory-mapped I/O space
+    this->finish_config_bars();
 
     this->pci_notify_bar_change = [this](int bar_num) {
         this->notify_bar_change(bar_num);

--- a/devices/memctrl/mpc106.cpp
+++ b/devices/memctrl/mpc106.cpp
@@ -86,6 +86,7 @@ uint32_t MPC106::read(uint32_t rgn_start, uint32_t offset, int size) {
             }
         }
         LOG_F(ERROR, "Attempt to read from unmapped PCI I/O space, offset=0x%X", offset);
+        // FIXME: add machine check exception (DEFAULT CATCH!, code=FFF00200)
     } else {
         if (offset >= 0x200000) {
             if (this->config_addr & 0x80)    // process only if bit E (enable) is set
@@ -125,8 +126,8 @@ uint32_t MPC106::pci_read(uint32_t offset, uint32_t size) {
     int reg_offs = (this->config_addr >> 24) & 0xFC;
 
     if (bus_num) {
-		LOG_F(ERROR, "%s: read attempt from non-local PCI bus, %02x:%02x.%x @%02x",
-            this->name.c_str(), bus_num, dev_num, fun_num, offset & 0xFCU);
+        LOG_F(ERROR, "%s: read attempt from non-local PCI bus, %02x:%02x.%x @%02x",
+            this->name.c_str(), bus_num, dev_num, fun_num, reg_offs + (offset & 3));
         return 0xFFFFFFFFUL; // PCI spec §6.1
     }
 
@@ -139,7 +140,7 @@ uint32_t MPC106::pci_read(uint32_t offset, uint32_t size) {
         return pci_conv_rd_data(result, details);
     } else {
         LOG_F(ERROR, "%s: read attempt from non-existing PCI device ??:%02x.%x @%02x",
-            this->name.c_str(), dev_num, fun_num, offset);
+            this->name.c_str(), dev_num, fun_num, reg_offs + (offset & 3));
     }
 
     return 0xFFFFFFFFUL; // PCI spec §6.1
@@ -152,8 +153,8 @@ void MPC106::pci_write(uint32_t offset, uint32_t value, uint32_t size) {
     int reg_offs = (this->config_addr >> 24) & 0xFC;
 
     if (bus_num) {
-		LOG_F(ERROR, "%s: write attempt to non-local PCI bus, %02x:%02x.%x @%02x",
-            this->name.c_str(), bus_num, dev_num, fun_num, offset & 0xFCU);
+        LOG_F(ERROR, "%s: write attempt to non-local PCI bus, %02x:%02x.%x @%02x",
+            this->name.c_str(), bus_num, dev_num, fun_num, reg_offs + (offset & 3));
         return;
     }
 
@@ -172,7 +173,7 @@ void MPC106::pci_write(uint32_t offset, uint32_t value, uint32_t size) {
         }
     } else {
         LOG_F(ERROR, "%s: write attempt to non-existing PCI device ??:%02x.%x @%02x",
-            this->name.c_str(), dev_num, fun_num, offset);
+            this->name.c_str(), dev_num, fun_num, reg_offs + (offset & 3));
     }
 }
 

--- a/devices/video/atimach64gx.cpp
+++ b/devices/video/atimach64gx.cpp
@@ -45,6 +45,7 @@ AtiMach64Gx::AtiMach64Gx()
     this->device_id   = ATI_MACH64_GX_DEV_ID;
     this->class_rev   = (0x030000 << 8) | 3;
     this->bars_cfg[0] = 0xFF000000UL; // declare main aperture (16MB)
+    this->finish_config_bars();
 
     this->pci_notify_bar_change = [this](int bar_num) {
         this->notify_bar_change(bar_num);

--- a/devices/video/atirage.cpp
+++ b/devices/video/atirage.cpp
@@ -127,6 +127,7 @@ ATIRage::ATIRage(uint16_t dev_id)
     this->bars_cfg[0] = 0xFF000000UL; // declare main aperture (16MB)
     this->bars_cfg[1] = 0xFFFFFF01UL; // declare I/O region (256 bytes)
     this->bars_cfg[2] = 0xFFFFF000UL; // declare register aperture (4KB)
+    this->finish_config_bars();
 
     this->pci_notify_bar_change = [this](int bar_num) {
         this->notify_bar_change(bar_num);

--- a/devices/video/control.cpp
+++ b/devices/video/control.cpp
@@ -62,6 +62,7 @@ ControlVideo::ControlVideo()
     this->bars_cfg[0] = 0xFFFFFFFFUL; // I/O region (4 bytes but it's weird because bit 1 is set)
     this->bars_cfg[1] = 0xFFFFF000UL; // base address for the HW registers (4KB)
     this->bars_cfg[2] = 0xFC000000UL; // base address for the VRAM (64MB)
+    this->finish_config_bars();
 
     this->pci_notify_bar_change = [this](int bar_num) {
         this->notify_bar_change(bar_num);


### PR DESCRIPTION
While dingusppc only emulates 32-bit Macs (for now), it is possible for a 32-bit Power Mac to use a PCIe card that has 64-bit BARs.

finish_config_bars is added to scan the cfg values of the BARs and determine their type. The type is stored separately so that it does not need to be determined again.
The type can be I/O (16 or 32 bit) or Mem (20 or 32 or 64 bit). A 64 bit bar is two BARs, the second contains the most significant 32 bits.

set_bar_value uses the stored type instead of trying to determine the type itself. It is always called even when the firmware is doing sizing. For sizing, It does the job of setting the bar value so do_bar_sizing is now just a stub.

Every PCIDevice that has a BAR needs to call finish_config_bars after setting up the cfg values just as they need to setup the cfg values. Since they need to do both, maybe the cfg values should be arguments of finish_config_bars, then finish_config_bars() should be renamed config_bars().