### PR TITLE
Clean up #includes

### DIFF
--- a/core/hostevents_sdl.cpp
+++ b/core/hostevents_sdl.cpp
@@ -20,8 +20,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <core/hostevents.h>
+#include <core/coresignal.h>
 #include <cpu/ppc/ppcemu.h>
-#include <loguru.hpp>
 #include <SDL.h>
 
 EventManager* EventManager::event_manager;

--- a/core/timermanager.cpp
+++ b/core/timermanager.cpp
@@ -25,7 +25,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "timermanager.h"
 
 #include <cinttypes>
-#include <memory>
 
 TimerManager* TimerManager::timer_manager;
 

--- a/cpu/ppc/poweropcodes.cpp
+++ b/cpu/ppc/poweropcodes.cpp
@@ -24,13 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "ppcemu.h"
 #include "ppcmmu.h"
-#include <array>
-#include <cmath>
-#include <iostream>
-#include <limits>
-#include <stdexcept>
-#include <stdio.h>
-#include <loguru.hpp>
+#include <stdint.h>
 
 // Affects the XER register's SO and OV Bits
 
@@ -158,7 +152,7 @@ void dppc_interpreter::power_lscbx() {
             //ppc_result_d = 0xFFFFFFFF;
             bitmask      = 0xFF000000;
             shift_amount = 24;
-        } 
+        }
         else {
             bitmask >>= 8;
             shift_amount -= 8;

--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -25,14 +25,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "ppcmmu.h"
 
 #include <algorithm>
-#include <functional>
 #include <iostream>
 #include <map>
 #include <setjmp.h>
 #include <stdexcept>
 #include <stdio.h>
 #include <string>
-#include <unordered_map>
 
 using namespace std;
 using namespace dppc_interpreter;

--- a/cpu/ppc/ppcfpopcodes.cpp
+++ b/cpu/ppc/ppcfpopcodes.cpp
@@ -23,18 +23,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "ppcemu.h"
 #include "ppcmmu.h"
-#include <array>
-#include <cfenv>
-#include <cfloat>
+#include <stdlib.h>
 #include <cinttypes>
 #include <cmath>
-#include <iostream>
 #include <limits>
-#include <map>
-#include <stdexcept>
-#include <stdio.h>
-#include <unordered_map>
-#include <loguru.hpp>
 
 // Used for FP calcs
 uint64_t ppc_result64_b;

--- a/cpu/ppc/ppcmmu.cpp
+++ b/cpu/ppc/ppcmmu.cpp
@@ -22,13 +22,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file PowerPC Memory Management Unit emulation. */
 
 #include <devices/memctrl/memctrlbase.h>
+#include <devices/common/mmiodevice.h>
 #include <memaccess.h>
 #include "ppcemu.h"
 #include "ppcmmu.h"
 
 #include <array>
 #include <cinttypes>
-#include <functional>
 #include <loguru.hpp>
 #include <stdexcept>
 

--- a/cpu/ppc/ppcmmu.h
+++ b/cpu/ppc/ppcmmu.h
@@ -26,10 +26,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <devices/memctrl/memctrlbase.h>
 
-#include <array>
 #include <cinttypes>
 #include <functional>
-#include <vector>
+
+class MMIODevice;
 
 /* Uncomment this to exhaustive MMU integrity checks. */
 //#define MMU_INTEGRITY_CHECKS

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -25,16 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <core/mathutils.h>
 #include "ppcemu.h"
 #include "ppcmmu.h"
-#include <array>
 #include <cinttypes>
-#include <cstring>
-#include <functional>
-#include <iostream>
-#include <stdexcept>
-#include <stdio.h>
-#include <stdlib.h>
-#include <loguru.hpp>
-#include <thread>
 #include <vector>
 
 uint32_t crf_d;

--- a/devices/common/adb/adb.cpp
+++ b/devices/common/adb/adb.cpp
@@ -26,10 +26,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <devices/common/adb/adb.h>
-#include <loguru.hpp>
-
-#include <cinttypes>
-#include <cstring>
 
 #if 0
 #include <thirdparty/SDL2/include/SDL.h>

--- a/devices/common/adb/adbbus.cpp
+++ b/devices/common/adb/adbbus.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file Apple Desktop Bus emulation. */
 
 #include <devices/common/adb/adbbus.h>
+#include <devices/common/adb/adbdevice.h>
 #include <devices/deviceregistry.h>
 #include <loguru.hpp>
 

--- a/devices/common/adb/adbbus.h
+++ b/devices/common/adb/adbbus.h
@@ -24,7 +24,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef ADB_BUS_H
 #define ADB_BUS_H
 
-#include <devices/common/adb/adbdevice.h>
 #include <devices/common/hwcomponent.h>
 
 #include <memory>

--- a/devices/common/adb/adbdevice.cpp
+++ b/devices/common/adb/adbdevice.cpp
@@ -23,7 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <core/timermanager.h>
 #include <devices/common/adb/adbdevice.h>
-#include <loguru.hpp>
+#include <devices/common/adb/adbbus.h>
 #include <machines/machinebase.h>
 
 AdbDevice::AdbDevice(std::string name) {

--- a/devices/common/adb/adbdevice.h
+++ b/devices/common/adb/adbdevice.h
@@ -24,11 +24,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef ADB_DEVICE_H
 #define ADB_DEVICE_H
 
-#include <devices/common/adb/adbbus.h>
 #include <devices/common/hwcomponent.h>
 
-#include <cstring>
-#include <functional>
 #include <string>
 
 /** Common ADB device addresses/types. */

--- a/devices/common/adb/adbkeyboard.cpp
+++ b/devices/common/adb/adbkeyboard.cpp
@@ -22,7 +22,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file Apple Desktop Bus Keyboard emulation. */
 
 #include <devices/common/adb/adbkeyboard.h>
+#include <devices/common/adb/adbbus.h>
 #include <devices/deviceregistry.h>
+#include <core/hostevents.h>
+#include <loguru.hpp>
 
 AdbKeyboard::AdbKeyboard(std::string name) : AdbDevice(name) {
     EventManager::get_instance()->add_keyboard_handler(this, &AdbKeyboard::event_handler);

--- a/devices/common/adb/adbkeyboard.h
+++ b/devices/common/adb/adbkeyboard.h
@@ -24,12 +24,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef ADB_KEYBOARD_H
 #define ADB_KEYBOARD_H
 
-#include <core/hostevents.h>
 #include <devices/common/adb/adbdevice.h>
 #include <devices/common/hwcomponent.h>
 
 #include <memory>
 #include <string>
+
+class KeyboardEvent;
 
 class AdbKeyboard : public AdbDevice {
 public:

--- a/devices/common/adb/adbmouse.cpp
+++ b/devices/common/adb/adbmouse.cpp
@@ -22,7 +22,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file Apple Desktop Bus Mouse emulation. */
 
 #include <devices/common/adb/adbmouse.h>
+#include <devices/common/adb/adbbus.h>
 #include <devices/deviceregistry.h>
+#include <core/hostevents.h>
+#include <loguru.hpp>
 
 AdbMouse::AdbMouse(std::string name) : AdbDevice(name) {
     EventManager::get_instance()->add_mouse_handler(this, &AdbMouse::event_handler);

--- a/devices/common/adb/adbmouse.h
+++ b/devices/common/adb/adbmouse.h
@@ -24,12 +24,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef ADB_MOUSE_H
 #define ADB_MOUSE_H
 
-#include <core/hostevents.h>
 #include <devices/common/adb/adbdevice.h>
 #include <devices/common/hwcomponent.h>
 
 #include <memory>
 #include <string>
+
+class MouseEvent;
 
 class AdbMouse : public AdbDevice {
 public:

--- a/devices/common/ata/atabasedevice.cpp
+++ b/devices/common/ata/atabasedevice.cpp
@@ -23,7 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <devices/common/ata/atabasedevice.h>
 #include <devices/common/ata/atadefs.h>
-#include <devices/deviceregistry.h>
+#include <devices/common/ata/idechannel.h>
 #include <loguru.hpp>
 
 #include <cinttypes>

--- a/devices/common/ata/atabasedevice.h
+++ b/devices/common/ata/atabasedevice.h
@@ -25,12 +25,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define ATA_BASE_DEVICE_H
 
 #include <devices/common/ata/atadefs.h>
-#include <devices/common/ata/idechannel.h>
 #include <devices/common/hwcomponent.h>
 #include "endianswap.h"
 
 #include <cinttypes>
 #include <string>
+
+class IdeChannel;
 
 class AtaBaseDevice : public HWComponent, public AtaInterface
 {

--- a/devices/common/ata/atapibasedevice.h
+++ b/devices/common/ata/atapibasedevice.h
@@ -25,7 +25,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define ATAPI_BASE_DEVICE_H
 
 #include <devices/common/ata/atabasedevice.h>
-#include <devices/common/ata/atadefs.h>
 
 #include <cinttypes>
 #include <string>

--- a/devices/common/ata/atapicdrom.cpp
+++ b/devices/common/ata/atapicdrom.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <devices/common/ata/atadefs.h>
 #include <devices/common/ata/atapicdrom.h>
+#include <devices/common/ata/idechannel.h>
 #include <devices/common/scsi/scsi.h> // ATAPI CDROM reuses SCSI commands (sic!)
 #include <devices/deviceregistry.h>
 #include <machines/machinebase.h>
@@ -279,7 +280,7 @@ uint16_t AtapiCdrom::get_data() {
         // For Mode 1 CD-ROMs:
         int area_start;
         int area_end = 0;
-        
+
         ret_data = 0xffff;
 
         if (this->sector_areas & 0x80) {

--- a/devices/common/ata/idechannel.cpp
+++ b/devices/common/ata/idechannel.cpp
@@ -32,6 +32,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/common/hwcomponent.h>
 #include <devices/deviceregistry.h>
 #include <machines/machinebase.h>
+#include <loguru.hpp>
 
 #include <cinttypes>
 #include <memory>

--- a/devices/common/dbdma.cpp
+++ b/devices/common/dbdma.cpp
@@ -24,6 +24,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cpu/ppc/ppcmmu.h>
 #include <devices/common/dbdma.h>
 #include <devices/common/dmacore.h>
+#include <devices/common/hwinterrupt.h>
+#include <devices/common/mmiodevice.h>
 #include <endianswap.h>
 #include <memaccess.h>
 

--- a/devices/common/dbdma.h
+++ b/devices/common/dbdma.h
@@ -30,10 +30,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define DB_DMA_H
 
 #include <devices/common/dmacore.h>
-#include <devices/common/hwinterrupt.h>
 
 #include <cinttypes>
-#include <functional>
+
+class InterruptCtrl;
 
 /** DBDMA Channel registers offsets */
 enum DMAReg : uint32_t {

--- a/devices/common/i2c/i2cprom.cpp
+++ b/devices/common/i2c/i2cprom.cpp
@@ -26,7 +26,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <cinttypes>
 #include <cstring>
-#include <memory>
 
 I2CProm::I2CProm(uint8_t dev_addr, int size)
 {

--- a/devices/common/nvram.cpp
+++ b/devices/common/nvram.cpp
@@ -26,7 +26,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cinttypes>
 #include <cstring>
 #include <fstream>
-#include <iostream>
 #include <loguru.hpp>
 
 /** @file Non-volatile RAM implementation.

--- a/devices/common/ofnvram.cpp
+++ b/devices/common/ofnvram.cpp
@@ -22,8 +22,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** Utilities for working with Apple Open Firmware and CHRP NVRAM partitions. */
 
 #include <devices/common/ofnvram.h>
+#include <devices/common/nvram.h>
 #include <endianswap.h>
-#include <loguru.hpp>
 #include <machines/machinebase.h>
 #include <memaccess.h>
 

--- a/devices/common/ofnvram.h
+++ b/devices/common/ofnvram.h
@@ -24,14 +24,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef OF_NVRAM_H
 #define OF_NVRAM_H
 
-#include <devices/common/nvram.h>
-
 #include <cinttypes>
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+class NVram;
 
 /** ========== Apple Open Firmware 1.x/2.x partition definitions. ========== */
 #define OF_NVRAM_OFFSET 0x1800

--- a/devices/common/pci/bandit.cpp
+++ b/devices/common/pci/bandit.cpp
@@ -27,7 +27,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <endianswap.h>
 #include <loguru.hpp>
 #include <machines/machinebase.h>
-#include <memaccess.h>
 
 #include <cinttypes>
 

--- a/devices/common/pci/bandit.h
+++ b/devices/common/pci/bandit.h
@@ -124,7 +124,7 @@ public:
 
 private:
     uint32_t                    base_addr;
-    unique_ptr<BanditPciDevice> my_pci_device;
+    std::unique_ptr<BanditPciDevice> my_pci_device;
 };
 
 /**

--- a/devices/common/pci/dec21154.cpp
+++ b/devices/common/pci/dec21154.cpp
@@ -24,7 +24,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/common/hwcomponent.h>
 #include <devices/common/pci/dec21154.h>
 #include <devices/deviceregistry.h>
-#include <endianswap.h>
 #include <loguru.hpp>
 
 #include <cinttypes>

--- a/devices/common/pci/pcibridge.cpp
+++ b/devices/common/pci/pcibridge.cpp
@@ -20,7 +20,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <devices/common/pci/pcibridge.h>
-#include <memaccess.h>
+#include <devices/common/pci/pcidevice.h>
+#include <devices/common/pci/pcihost.h>
+#include <loguru.hpp>
 
 PCIBridge::PCIBridge(std::string name) : PCIDevice(name)
 {

--- a/devices/common/pci/pcibridge.h
+++ b/devices/common/pci/pcibridge.h
@@ -22,14 +22,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef PCI_BRIDGE_H
 #define PCI_BRIDGE_H
 
-#include <devices/deviceregistry.h>
 #include <devices/common/pci/pcidevice.h>
 #include <devices/common/pci/pcihost.h>
 
 #include <cinttypes>
 #include <string>
-#include <unordered_map>
-#include <vector>
 
 /** PCI configuration space registers offsets */
 enum {

--- a/devices/common/pci/pcidevice.cpp
+++ b/devices/common/pci/pcidevice.cpp
@@ -20,9 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <devices/common/pci/pcidevice.h>
-#include <endianswap.h>
 #include <loguru.hpp>
-#include <memaccess.h>
 
 #include <cinttypes>
 #include <fstream>

--- a/devices/common/pci/pcihost.cpp
+++ b/devices/common/pci/pcihost.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/common/hwcomponent.h>
 #include <devices/common/pci/pcibridge.h>
 #include <devices/common/pci/pcihost.h>
+#include <devices/deviceregistry.h>
 #include <devices/memctrl/memctrlbase.h>
 #include <machines/machinebase.h>
 #include <endianswap.h>

--- a/devices/common/pci/pcihost.h
+++ b/devices/common/pci/pcihost.h
@@ -23,10 +23,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define PCI_HOST_H
 
 #include <core/bitops.h>
-#include <devices/deviceregistry.h>
 #include <endianswap.h>
 
-#include <array>
 #include <cinttypes>
 #include <string>
 #include <unordered_map>

--- a/devices/common/scsi/mesh.cpp
+++ b/devices/common/scsi/mesh.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <core/timermanager.h>
 #include <devices/common/hwinterrupt.h>
 #include <devices/common/scsi/mesh.h>
+#include <devices/common/scsi/scsi.h>
 #include <devices/deviceregistry.h>
 #include <loguru.hpp>
 #include <machines/machinebase.h>

--- a/devices/common/scsi/mesh.h
+++ b/devices/common/scsi/mesh.h
@@ -25,11 +25,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define MESH_H
 
 #include <devices/common/hwcomponent.h>
-#include <devices/common/hwinterrupt.h>
-#include <devices/common/scsi/scsi.h>
 
 #include <cinttypes>
 #include <memory>
+
+class InterruptCtrl;
+class ScsiBus;
 
 // Chip ID returned by the MESH cell inside the Heathrow ASIC
 #define HeathrowMESHID  4

--- a/devices/common/scsi/sc53c94.cpp
+++ b/devices/common/scsi/sc53c94.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file NCR53C94/Am53CF94 SCSI controller emulation. */
 
 #include <core/timermanager.h>
+#include <devices/common/dmacore.h>
 #include <devices/common/hwcomponent.h>
 #include <devices/common/hwinterrupt.h>
 #include <devices/common/scsi/sc53c94.h>

--- a/devices/common/scsi/sc53c94.h
+++ b/devices/common/scsi/sc53c94.h
@@ -29,12 +29,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef SC_53C94_H
 #define SC_53C94_H
 
-#include <devices/common/dmacore.h>
 #include <devices/common/scsi/scsi.h>
-#include <devices/common/hwinterrupt.h>
 
 #include <cinttypes>
 #include <memory>
+
+class DmaBidirChannel;
+class InterruptCtrl;
 
 #define DATA_FIFO_MAX   16
 

--- a/devices/common/scsi/scsicdrom.cpp
+++ b/devices/common/scsi/scsicdrom.cpp
@@ -30,7 +30,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <cinttypes>
 #include <cstring>
-#include <stdio.h>
 #include <sys/stat.h>
 
 using namespace std;

--- a/devices/common/scsi/scsihd.cpp
+++ b/devices/common/scsi/scsihd.cpp
@@ -25,13 +25,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/common/scsi/scsihd.h>
 #include <devices/deviceregistry.h>
 #include <loguru.hpp>
-#include <machines/machinebase.h>
 #include <machines/machineproperties.h>
 #include <memaccess.h>
 
 #include <fstream>
 #include <cstring>
-#include <stdio.h>
 #include <sys/stat.h>
 
 #define HDD_SECTOR_SIZE 512

--- a/devices/common/scsi/scsihd.h
+++ b/devices/common/scsi/scsihd.h
@@ -29,7 +29,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cinttypes>
 #include <fstream>
 #include <memory>
-#include <stdio.h>
 #include <string>
 
 class ScsiHardDisk : public ScsiDevice {

--- a/devices/common/viacuda.cpp
+++ b/devices/common/viacuda.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <core/hostevents.h>
 #include <core/timermanager.h>
+#include <devices/common/adb/adbbus.h>
 #include <devices/common/hwinterrupt.h>
 #include <devices/common/viacuda.h>
 #include <devices/deviceregistry.h>
@@ -32,7 +33,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <memaccess.h>
 
 #include <cinttypes>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/devices/common/viacuda.h
+++ b/devices/common/viacuda.h
@@ -43,13 +43,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef VIACUDA_H
 #define VIACUDA_H
 
-#include <devices/common/adb/adbbus.h>
 #include <devices/common/hwcomponent.h>
-#include <devices/common/hwinterrupt.h>
 #include <devices/common/i2c/i2c.h>
 #include <devices/common/nvram.h>
 
 #include <memory>
+
+class AdbBus;
+class InterruptCtrl;
 
 #define VIA_CLOCK_HZ 783360
 

--- a/devices/deviceregistry.cpp
+++ b/devices/deviceregistry.cpp
@@ -24,7 +24,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/deviceregistry.h>
 #include <devices/common/hwcomponent.h>
 
-#include <memory>
 #include <string>
 
 bool DeviceRegistry::add(const std::string name, DeviceDescription desc)

--- a/devices/deviceregistry.h
+++ b/devices/deviceregistry.h
@@ -24,7 +24,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DEVICE_REGISTRY_H
 #define DEVICE_REGISTRY_H
 
-#include <devices/common/hwcomponent.h>
 #include <machines/machineproperties.h>
 
 #include <functional>
@@ -32,6 +31,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <map>
 #include <vector>
+
+class HWComponent;
 
 typedef std::function<unique_ptr<HWComponent> ()> CreateFunc;
 

--- a/devices/floppy/superdrive.cpp
+++ b/devices/floppy/superdrive.cpp
@@ -27,7 +27,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <loguru.hpp>
 
 #include <cinttypes>
-#include <memory>
 
 using namespace MacSuperdrive;
 

--- a/devices/floppy/swim3.cpp
+++ b/devices/floppy/swim3.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <core/timermanager.h>
 #include <devices/deviceregistry.h>
+#include <devices/common/dmacore.h>
 #include <devices/common/hwinterrupt.h>
 #include <devices/floppy/superdrive.h>
 #include <devices/floppy/swim3.h>
@@ -31,7 +32,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <machines/machineproperties.h>
 
 #include <cinttypes>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/devices/floppy/swim3.h
+++ b/devices/floppy/swim3.h
@@ -24,13 +24,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef SWIM3_H
 #define SWIM3_H
 
-#include <devices/common/dmacore.h>
 #include <devices/common/hwcomponent.h>
-#include <devices/common/hwinterrupt.h>
 #include <devices/floppy/superdrive.h>
 
 #include <cinttypes>
 #include <memory>
+
+class DmaBidirChannel;
+class InterruptCtrl;
 
 /** SWIM3 registers offsets. */
 namespace Swim3 {

--- a/devices/ioctrl/amic.h
+++ b/devices/ioctrl/amic.h
@@ -24,19 +24,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef AMIC_H
 #define AMIC_H
 
+#include <devices/common/dmacore.h>
 #include <devices/common/hwinterrupt.h>
 #include <devices/common/mmiodevice.h>
-#include <devices/common/scsi/sc53c94.h>
-#include <devices/common/viacuda.h>
-#include <devices/ethernet/mace.h>
-#include <devices/floppy/swim3.h>
-#include <devices/serial/escc.h>
 #include <devices/sound/awacs.h>
 #include <devices/video/displayid.h>
 #include <devices/video/pdmonboard.h>
 
 #include <cinttypes>
 #include <memory>
+
+class EsccController;
+class MaceController;
+class Sc53C94;
+class ViaCuda;
+namespace Swim3 { class Swim3Ctrl; }
 
 /** Interrupt related constants. */
 

--- a/devices/ioctrl/ohare.cpp
+++ b/devices/ioctrl/ohare.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <cpu/ppc/ppcemu.h>
+#include <devices/deviceregistry.h>
 #include <devices/ioctrl/macio.h>
 #include <endianswap.h>
 #include <loguru.hpp>

--- a/devices/memctrl/memctrlbase.cpp
+++ b/devices/memctrl/memctrlbase.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <devices/memctrl/memctrlbase.h>
+#include <devices/common/mmiodevice.h>
 
 #include <algorithm>    // to shut up MSVC errors (:
 #include <cstring>

--- a/devices/memctrl/memctrlbase.h
+++ b/devices/memctrl/memctrlbase.h
@@ -22,11 +22,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef MEMORY_CONTROLLER_BASE_H
 #define MEMORY_CONTROLLER_BASE_H
 
-#include <devices/common/mmiodevice.h>
-
 #include <cinttypes>
 #include <string>
 #include <vector>
+
+class MMIODevice;
 
 // Common DRAM capacities.
 enum {

--- a/devices/memctrl/mpc106.cpp
+++ b/devices/memctrl/mpc106.cpp
@@ -22,17 +22,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** MPC106 (Grackle) emulation. */
 
 #include <devices/common/hwcomponent.h>
-#include <devices/common/mmiodevice.h>
 #include <devices/deviceregistry.h>
 #include <devices/memctrl/memctrlbase.h>
 #include <devices/memctrl/mpc106.h>
 #include <loguru.hpp>
-#include <memaccess.h>
 
 #include <cinttypes>
 #include <cstring>
 #include <string>
-#include <vector>
 
 MPC106::MPC106() : MemCtrlBase(), PCIDevice("Grackle"), PCIHost()
 {

--- a/devices/memctrl/mpc106.h
+++ b/devices/memctrl/mpc106.h
@@ -34,14 +34,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef MPC106_H
 #define MPC106_H
 
-#include <devices/common/mmiodevice.h>
 #include <devices/common/pci/pcidevice.h>
 #include <devices/common/pci/pcihost.h>
 #include <devices/memctrl/memctrlbase.h>
 
 #include <cinttypes>
 #include <memory>
-#include <unordered_map>
 
 /** Grackle configuration space registers. */
 enum GrackleReg : uint32_t {

--- a/devices/memctrl/platinum.cpp
+++ b/devices/memctrl/platinum.cpp
@@ -27,7 +27,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <loguru.hpp>
 
 #include <cinttypes>
-#include <memory>
 
 using namespace Platinum;
 

--- a/devices/sound/awacs.cpp
+++ b/devices/sound/awacs.cpp
@@ -32,9 +32,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <endianswap.h>
 #include <machines/machinebase.h>
 
-#include <algorithm>
 #include <loguru.hpp>
-#include <memory>
 
 AwacsBase::AwacsBase(std::string name)
 {

--- a/devices/sound/awacs.h
+++ b/devices/sound/awacs.h
@@ -28,14 +28,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef AWAC_H
 #define AWAC_H
 
-#include <devices/common/dmacore.h>
 #include <devices/common/hwcomponent.h>
 #include <devices/common/i2c/i2c.h>
-#include <devices/sound/soundserver.h>
 
 #include <cinttypes>
 #include <memory>
 #include <string>
+
+class DmaOutChannel;
+class SoundServer;
 
 /** Base class for the AWACs codecs. */
 class AwacsBase : public HWComponent {

--- a/devices/sound/burgundy.cpp
+++ b/devices/sound/burgundy.cpp
@@ -27,7 +27,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/sound/burgundy.h>
 #include <endianswap.h>
 #include <loguru.hpp>
-#include <memaccess.h>
 
 BurgundyCodec::BurgundyCodec(std::string name) : MacioSndCodec(name)
 {

--- a/devices/storage/blockstoragedevice.cpp
+++ b/devices/storage/blockstoragedevice.cpp
@@ -22,9 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file Block storage device implementation. */
 
 #include <devices/storage/blockstoragedevice.h>
-#include <loguru.hpp>
 
-#include <stdio.h>
 #include <sys/stat.h>
 
 using namespace std;

--- a/devices/video/atimach64gx.h
+++ b/devices/video/atimach64gx.h
@@ -25,7 +25,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define ATI_MACH64_GX_H
 
 #include <devices/common/pci/pcidevice.h>
-#include <devices/video/atimach64defs.h>
 #include <devices/video/displayid.h>
 #include <devices/video/videoctrl.h>
 

--- a/devices/video/atirage.cpp
+++ b/devices/video/atirage.cpp
@@ -29,10 +29,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <loguru.hpp>
 #include <memaccess.h>
 
-#include <chrono>
-#include <cstdint>
 #include <map>
-#include <memory>
 
 /* Mach64 post dividers. */
 static const int mach64_post_div[8] = {

--- a/devices/video/pdmonboard.h
+++ b/devices/video/pdmonboard.h
@@ -24,10 +24,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef PDM_ONBOARD_H
 #define PDM_ONBOARD_H
 
-#include <devices/memctrl/hmc.h>
 #include <devices/video/videoctrl.h>
 
 #include <cinttypes>
+
+class HMC;
+class InterruptCtrl;
 
 #define PDM_VMODE_OFF   0x1F
 

--- a/devices/video/videoctrl.cpp
+++ b/devices/video/videoctrl.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file Video Conroller base class implementation. */
 
 #include <core/timermanager.h>
+#include <devices/common/hwinterrupt.h>
 #include <devices/video/videoctrl.h>
 #include <memaccess.h>
 

--- a/devices/video/videoctrl.h
+++ b/devices/video/videoctrl.h
@@ -24,12 +24,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef VIDEO_CTRL_H
 #define VIDEO_CTRL_H
 
-#include <core/hostevents.h>
-#include <devices/common/hwinterrupt.h>
 #include <devices/video/display.h>
 
 #include <cinttypes>
 #include <functional>
+
+class InterruptCtrl;
+class WindowEvent;
 
 class VideoCtrlBase {
 public:

--- a/machines/machinebase.cpp
+++ b/machines/machinebase.cpp
@@ -24,7 +24,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <machines/machinebase.h>
 
 #include <map>
-#include <memory>
 #include <string>
 
 std::unique_ptr<MachineBase> gMachineObj = 0;

--- a/machines/machinebase.h
+++ b/machines/machinebase.h
@@ -27,11 +27,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef MACHINE_BASE_H
 #define MACHINE_BASE_H
 
-#include <devices/common/hwcomponent.h>
-
 #include <map>
 #include <memory>
 #include <string>
+
+class HWComponent;
+enum HWCompType : uint64_t;
 
 class MachineBase {
 public:

--- a/machines/machinecatalyst.cpp
+++ b/machines/machinecatalyst.cpp
@@ -22,15 +22,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file Constructs a Catalyst (Power Macintosh 7200) machine. */
 
 #include <cpu/ppc/ppcemu.h>
-#include <devices/common/pci/bandit.h>
-#include <devices/ioctrl/macio.h>
+#include <devices/common/hwcomponent.h>
+#include <devices/common/pci/pcidevice.h>
+#include <devices/common/pci/pcihost.h>
 #include <devices/memctrl/platinum.h>
 #include <loguru.hpp>
 #include <machines/machinebase.h>
 #include <machines/machinefactory.h>
 #include <machines/machineproperties.h>
+#include <memctrl/memctrlbase.h>
 
-#include <memory>
 #include <string>
 
 int initialize_catalyst(std::string& id)

--- a/machines/machinefactory.cpp
+++ b/machines/machinefactory.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     Author: Max Poliakovski
  */
 
+#include <devices/common/hwcomponent.h>
 #include <devices/deviceregistry.h>
 #include <devices/memctrl/memctrlbase.h>
 #include <devices/sound/soundserver.h>
@@ -36,11 +37,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cinttypes>
 #include <cstring>
 #include <fstream>
-#include <functional>
+#include <tuple>
 #include <iostream>
 #include <iomanip>
 #include <map>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/machines/machinefactory.h
+++ b/machines/machinefactory.h
@@ -27,17 +27,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef MACHINE_FACTORY_H
 #define MACHINE_FACTORY_H
 
-#include <devices/deviceregistry.h>
-#include <machines/machinebase.h>
 #include <machines/machineproperties.h>
 
-#include <fstream>
-#include <functional>
 #include <map>
 #include <string>
 #include <vector>
 
 using namespace std;
+
+struct DeviceDescription;
 
 struct MachineDescription {
     string                  name;

--- a/machines/machinegazelle.cpp
+++ b/machines/machinegazelle.cpp
@@ -24,12 +24,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <cpu/ppc/ppcemu.h>
+#include <devices/common/hwcomponent.h>
 #include <devices/memctrl/psx.h>
+#include <devices/common/pci/pcidevice.h>
 #include <devices/common/pci/pcihost.h>
-#include <devices/ioctrl/macio.h>
 #include <machines/machinebase.h>
 #include <machines/machinefactory.h>
 #include <machines/machineproperties.h>
+#include <memctrl/memctrlbase.h>
+#include <loguru.hpp>
 
 // TODO: move it to /cpu/ppc
 int get_cpu_pll_value(const uint64_t cpu_freq_hz) {

--- a/machines/machinegossamer.cpp
+++ b/machines/machinegossamer.cpp
@@ -25,10 +25,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <cpu/ppc/ppcemu.h>
+#include <devices/common/hwcomponent.h>
+#include <devices/common/i2c/i2c.h>
 #include <devices/common/i2c/athens.h>
 #include <devices/common/i2c/i2cprom.h>
 #include <devices/common/machineid.h>
-#include <devices/ioctrl/macio.h>
 #include <devices/memctrl/mpc106.h>
 #include <devices/memctrl/spdram.h>
 #include <loguru.hpp>
@@ -37,7 +38,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <machines/machineproperties.h>
 
 #include <cinttypes>
-#include <memory>
 #include <string>
 
 // Bit definitions for the Gossamer system register at 0xFF000004

--- a/machines/machinepdm.cpp
+++ b/machines/machinepdm.cpp
@@ -25,7 +25,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <cpu/ppc/ppcemu.h>
+#include <devices/common/hwcomponent.h>
 #include <devices/common/machineid.h>
+#include <devices/common/mmiodevice.h>
 #include <devices/common/scsi/scsi.h>
 #include <devices/common/scsi/scsicdrom.h>
 #include <devices/common/scsi/scsihd.h>

--- a/machines/machineproperties.cpp
+++ b/machines/machineproperties.cpp
@@ -20,8 +20,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "machineproperties.h"
+#include <loguru.hpp>
 
-#include <algorithm>
 #include <cinttypes>
 #include <string>
 #include <sstream>

--- a/machines/machineproperties.h
+++ b/machines/machineproperties.h
@@ -19,14 +19,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <loguru.hpp>
-
 #include <cinttypes>
 #include <limits>
 #include <map>
-#include <memory>
 #include <string>
 #include <vector>
+#include <memory>
 
 #ifndef MACHINE_PROPERTIES_H
 #define MACHINE_PROPERTIES_H

--- a/machines/machinetnt.cpp
+++ b/machines/machinetnt.cpp
@@ -22,15 +22,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /** @file Constructs a TNT (Power Macintosh 7500, 8500 etc) machine. */
 
 #include <cpu/ppc/ppcemu.h>
-#include <devices/common/pci/bandit.h>
-#include <devices/ioctrl/macio.h>
+#include <devices/common/pci/pcihost.h>
+#include <devices/common/pci/pcidevice.h>
 #include <devices/memctrl/hammerhead.h>
 #include <loguru.hpp>
 #include <machines/machinebase.h>
 #include <machines/machinefactory.h>
 #include <machines/machineproperties.h>
 
-#include <memory>
 #include <string>
 
 int initialize_tnt(std::string& id)

--- a/machines/machineyosemite.cpp
+++ b/machines/machineyosemite.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/common/pci/dec21154.h>
 #include <devices/memctrl/mpc106.h>
 #include <devices/memctrl/spdram.h>
+#include <machines/machinebase.h>
 #include <machines/machinefactory.h>
 #include <machines/machineproperties.h>
 

--- a/main.cpp
+++ b/main.cpp
@@ -26,18 +26,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <core/timermanager.h>
 #include <cpu/ppc/ppcemu.h>
 #include <debugger/debugger.h>
+#include <machines/machinebase.h>
 #include <machines/machinefactory.h>
-#include <machines/machineproperties.h>
 #include <utils/profiler.h>
 #include <main.h>
 
 #include <cinttypes>
 #include <csignal>
 #include <cstring>
-#include <fstream>
 #include <iostream>
-#include <sstream>
-#include <stdio.h>
 #include <CLI11.hpp>
 #include <loguru.hpp>
 

--- a/utils/profiler.cpp
+++ b/utils/profiler.cpp
@@ -21,7 +21,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "profiler.h"
 #include <iostream>
-#include <memory>
 #include <vector>
 
 /** global profiler object */


### PR DESCRIPTION
Result of running IWYU (https://include-what-you-use.org/) and applying most of the suggestions about unncessary includes and forward declarations.

Was motivated by observing that `<thread>` was being included in `ppcopcodes.cpp` even though it was unused (found while researching the use of threads), but seems generally good to help with build times and correctness.