### PR TITLE
amic: don't reset cur_buf_pos if we've drained the DMA buffer

### DIFF
--- a/devices/ioctrl/amic.cpp
+++ b/devices/ioctrl/amic.cpp
@@ -546,7 +546,6 @@ DmaPullResult AmicSndOutDma::pull_data(uint32_t req_len, uint32_t *avail_len,
         // if it's false stop delivering sound data
         // this will effectively stop audio playback
         if (this->snd_buf_num && !this->enabled) {
-            this->cur_buf_pos = 0;
             return DmaPullResult::NoMoreData;
         }
 


### PR DESCRIPTION
Otherwise if pull_data is called again, it will think that it still has data available in the buffer (rem_len will be non-zero) and random data at the buffer location will be returned.

This manifested itself as noise being played back in the JS implementation of the SoundServer. The cubeb implementation was not affected because it stops polling once it's told it has no more data in the buffer. Both approaches are valid (the JS version pads data with silence), and the DMA buffer should support both.