### PR TITLE
Move disk image reading to be behind an ImgFile class

### DIFF
--- a/devices/common/scsi/scsicdrom.h
+++ b/devices/common/scsi/scsicdrom.h
@@ -25,9 +25,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define SCSI_CDROM_H
 
 #include <devices/common/scsi/scsi.h>
+#include <utils/imgfile.h>
 
 #include <cinttypes>
-#include <fstream>
 #include <memory>
 #include <string>
 
@@ -74,7 +74,7 @@ private:
     AddrMsf lba_to_msf(const int lba);
 
 private:
-    std::fstream    cdr_img;
+    ImgFile         cdr_img;
     uint64_t        img_size;
     int             total_frames;
     int             num_tracks;

--- a/devices/common/scsi/scsihd.h
+++ b/devices/common/scsi/scsihd.h
@@ -25,9 +25,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define SCSI_HD_H
 
 #include <devices/common/scsi/scsi.h>
+#include <utils/imgfile.h>
 
 #include <cinttypes>
-#include <fstream>
 #include <memory>
 #include <string>
 
@@ -60,7 +60,7 @@ protected:
     void rewind();
 
 private:
-    std::fstream    hdd_img;
+    ImgFile         hdd_img;
     uint64_t        img_size;
     int             total_blocks;
     uint64_t        file_offset = 0;

--- a/devices/storage/blockstoragedevice.h
+++ b/devices/storage/blockstoragedevice.h
@@ -24,8 +24,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef BLOCK_STORAGE_DEVICE_H
 #define BLOCK_STORAGE_DEVICE_H
 
+#include <utils/imgfile.h>
+
 #include <cinttypes>
-#include <fstream>
 #include <memory>
 #include <string>
 
@@ -45,7 +46,7 @@ public:
     int write_begin(char *buf, int nblocks);
 
 protected:
-    std::fstream    img_file     = {};
+    ImgFile         img_file;
     uint64_t        size_bytes   = 0;   // image file size in bytes
     uint64_t        size_blocks  = 0;   // image file size in blocks
     uint64_t        cur_fpos     = 0;   // current image file pointer position

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,6 +1,9 @@
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(PlatformGlob)
+
 include_directories("${PROJECT_SOURCE_DIR}")
 
-file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+platform_glob(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
 add_library(utils OBJECT ${SOURCES})
 target_link_libraries(utils PRIVATE)

--- a/utils/imgfile.h
+++ b/utils/imgfile.h
@@ -19,33 +19,31 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-/** @file ATA hard disk definitions. */
+/** @file Image file abstraction for floppy, hard drive and CD-ROM images
+ * (implemented on each platform). */
 
-#ifndef ATA_HARD_DISK_H
-#define ATA_HARD_DISK_H
+#ifndef IMGFILE_H
+#define IMGFILE_H
 
-#include <devices/common/ata/atabasedevice.h>
-#include <utils/imgfile.h>
-
+#include <cstddef>
+#include <memory>
 #include <string>
 
-#define ATA_HD_SEC_SIZE 512
-
-class AtaHardDisk : public AtaBaseDevice
-{
+class ImgFile {
 public:
-    AtaHardDisk();
-    ~AtaHardDisk() = default;
+    ImgFile();
+    ~ImgFile();
 
-    void insert_image(std::string filename);
-    int perform_command() override;
+    bool open(const std::string& img_path);
+    void close();
 
+    size_t size() const;
+
+    size_t read(void* buf, off_t offset, size_t length) const;
+    size_t write(const void* buf, off_t offset, size_t length);
 private:
-    ImgFile         hdd_img;
-    uint64_t img_size;
-    char * buffer = new char[1 <<17];
-
-    uint8_t hd_id_data[ATA_HD_SEC_SIZE] = {};
+    class Impl; // Holds private fields
+    std::unique_ptr<Impl> impl;
 };
 
-#endif // ATA_HARD_DISK_H
+#endif // IMGFILE_H

--- a/utils/imgfile_sdl.cpp
+++ b/utils/imgfile_sdl.cpp
@@ -1,0 +1,67 @@
+/*
+DingusPPC - The Experimental PowerPC Macintosh emulator
+Copyright (C) 2018-23 divingkatae and maximum
+                      (theweirdo)     spatium
+
+(Contact divingkatae#1017 or powermax#2286 on Discord for more info)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <utils/imgfile.h>
+
+#include <fstream>
+
+class ImgFile::Impl {
+public:
+    std::fstream stream;
+};
+
+ImgFile::ImgFile(): impl(std::make_unique<Impl>())
+{
+
+}
+
+ImgFile::~ImgFile() = default;
+
+bool ImgFile::open(const std::string &img_path)
+{
+    impl->stream.open(img_path, std::ios::in | std::ios::out | std::ios::binary);
+    return !impl->stream.fail();
+}
+
+void ImgFile::close()
+{
+    impl->stream.close();
+}
+
+size_t ImgFile::size() const
+{
+    impl->stream.seekg(0, impl->stream.end);
+    return impl->stream.tellg();
+}
+
+size_t ImgFile::read(void* buf, off_t offset, size_t length) const
+{
+    impl->stream.seekg(offset, std::ios::beg);
+    impl->stream.read((char *)buf, length);
+    return impl->stream.gcount();
+}
+
+size_t ImgFile::write(const void* buf, off_t offset, size_t length)
+{
+    impl->stream.seekg(offset, std::ios::beg);
+    impl->stream.write((const char *)buf, length);
+    return impl->stream.gcount();
+}


### PR DESCRIPTION
Allows different implementations for different platforms (the JS build relies on browser APIs to stream disk images over the network).

Setting aside the JS build, this also reduces some code duplication.