### PR TITLE
Fix "a" key always being as as a keyup

### DIFF
--- a/devices/common/adb/adbkeyboard.cpp
+++ b/devices/common/adb/adbkeyboard.cpp
@@ -61,9 +61,10 @@ bool AdbKeyboard::get_register_0() {
         out_buf[0] = (this->key_state << 7) | (this->key & 0x7F);
         // It's possible that we get two events before the host polls us, but
         // in practice it has not come up. We need to set the key status bit to
-        // 1 (released), otherwise if we leave it empty, the host will think
-        // that the a key (code 0) is pressed.
-        out_buf[1] = 1 << 7;
+        // 1 (released), and the key to a non-existent one (0x7F). Otherwise if
+        // we leave it empty, the host will think that the 'a' key (code 0) is
+        // pressed.
+        out_buf[1] = 0xFF;
 
         this->key           = 0;
         this->key_state     = 0;


### PR DESCRIPTION
We were using an empty value on the second byte of the ADB keyboard register 0, but that maps to the "a" key. This manifested itself as the Key Caps DA never showing the "a" key as being down.

Switch to a non-existent key for the second byte.