### PR TITLE
Fix keyboard events occasionally being dropped

### DIFF
--- a/devices/common/adb/adbkeyboard.h
+++ b/devices/common/adb/adbkeyboard.h
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/common/adb/adbdevice.h>
 #include <devices/common/hwcomponent.h>
 
+#include <deque>
 #include <memory>
 #include <string>
 
@@ -50,9 +51,9 @@ public:
 
 
 private:
-    uint32_t key          = 0;
-    uint8_t key_state     = 0;
-    bool changed          = false;
+    std::deque<std::unique_ptr<KeyboardEvent>> pending_events;
+
+    uint8_t consume_pending_event();
 };
 
 // ADB Extended Keyboard raw key codes (most of which eventually became virtual


### PR DESCRIPTION
AdbKeyboard would copy the event into its own fields and set the changed field, so that we could return the event when register was 0. However, if a subsequent event was received before ADB polling, the previous event would be overwritten and lost.

Fix this by maintaining a queue of events, so that we can return everything since the last poll.