### PR TITLE
Fix emulation of doz, dozi, and nabs POWER instructions

### DIFF
--- a/cpu/ppc/poweropcodes.cpp
+++ b/cpu/ppc/poweropcodes.cpp
@@ -115,7 +115,7 @@ void dppc_interpreter::power_doz() {
     if (oe_flag)
         power_setsoov(ppc_result_a, ppc_result_b, ppc_result_d);
 
-    ppc_store_result_rega();
+    ppc_store_result_regd();
 }
 
 void dppc_interpreter::power_dozi() {
@@ -125,7 +125,7 @@ void dppc_interpreter::power_dozi() {
     } else {
         ppc_result_d = simm - ppc_result_a;
     }
-    ppc_store_result_rega();
+    ppc_store_result_regd();
 }
 
 void dppc_interpreter::power_lscbx() {
@@ -223,7 +223,7 @@ void dppc_interpreter::power_mul() {
 
 void dppc_interpreter::power_nabs() {
     ppc_grab_regsda();
-    ppc_result_d = (0x80000000 | ppc_result_a);
+    ppc_result_d = ppc_result_a & 0x80000000 ? ppc_result_a : -ppc_result_a;
 
     if (rc_flag)
         ppc_changecrf0(ppc_result_d);


### PR DESCRIPTION
doz and dozi were storing the result into the wrong register.

nabs was not taking into account two's complement storage of numbers and was just setting the signed bit.

These two instructions are used in the implementation of text measurement in native QuickDraw on 7.1.2/the PDM ROM, and the incorrect values were resulting in nothing being rendered. With the fix text appears when booting from the 7.1.2 CD.