### PR TITLE
Inline ppc_set_cur_instruction

### DIFF
--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <devices/memctrl/memctrlbase.h>
 #include <endianswap.h>
+#include <memaccess.h>
 
 #include <cinttypes>
 #include <functional>
@@ -323,7 +324,7 @@ enum class Except_Type {
     EXC_TRACE   = 13
 };
 
-/** Programm Exception subclasses. */
+/** Program Exception subclasses. */
 enum Exc_Cause : uint32_t {
     FPU_OFF     = 1 << (31 - 11),
     ILLEGAL_OP  = 1 << (31 - 12),
@@ -352,6 +353,10 @@ extern bool oe_flag;    // Overflow flag
 extern uint32_t ppc_cur_instruction;
 extern uint32_t ppc_effective_address;
 extern uint32_t ppc_next_instruction_address;
+
+inline void ppc_set_cur_instruction(const uint8_t* ptr) {
+    ppc_cur_instruction = READ_DWORD_BE_A(ptr);
+}
 
 // Profiling Stats
 #ifdef CPU_PROFILING

--- a/cpu/ppc/ppcmmu.cpp
+++ b/cpu/ppc/ppcmmu.cpp
@@ -83,10 +83,6 @@ AddressMapEntry last_exec_area  = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullpt
 AddressMapEntry last_ptab_area  = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullptr};
 AddressMapEntry last_dma_area   = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullptr};
 
-void ppc_set_cur_instruction(const uint8_t* ptr) {
-    ppc_cur_instruction = READ_DWORD_BE_A(ptr);
-}
-
 /** 601-style block address translation. */
 static BATResult mpc601_block_address_translation(uint32_t la)
 {

--- a/cpu/ppc/ppcmmu.h
+++ b/cpu/ppc/ppcmmu.h
@@ -123,7 +123,6 @@ extern void mmu_change_mode(void);
 extern void mmu_pat_ctx_changed();
 extern void tlb_flush_entry(uint32_t ea);
 
-extern void ppc_set_cur_instruction(const uint8_t* ptr);
 extern uint64_t mem_read_dbg(uint32_t virt_addr, uint32_t size);
 uint8_t *mmu_translate_imem(uint32_t vaddr);
 


### PR DESCRIPTION
It's used in the main emulator loop (ppc_exec_inner), and the function call overhead adds up.

By inlining it, time to boot to the Finder using a 7.1.2 install CD and a 6100 ROM goes from ~6700ms to ~6400ms (with clang 14 on a M2 Max)