### PR TITLE
Add 2, 4, 15, 24 bpp support for PDM video

### DIFF
--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <devices/memctrl/memctrlbase.h>
 #include <endianswap.h>
+#include <memaccess.h>
 
 #include <cinttypes>
 #include <functional>
@@ -323,7 +324,7 @@ enum class Except_Type {
     EXC_TRACE   = 13
 };
 
-/** Programm Exception subclasses. */
+/** Program Exception subclasses. */
 enum Exc_Cause : uint32_t {
     FPU_OFF     = 1 << (31 - 11),
     ILLEGAL_OP  = 1 << (31 - 12),
@@ -352,6 +353,10 @@ extern bool oe_flag;    // Overflow flag
 extern uint32_t ppc_cur_instruction;
 extern uint32_t ppc_effective_address;
 extern uint32_t ppc_next_instruction_address;
+
+inline void ppc_set_cur_instruction(const uint8_t* ptr) {
+    ppc_cur_instruction = READ_DWORD_BE_A(ptr);
+}
 
 // Profiling Stats
 #ifdef CPU_PROFILING

--- a/cpu/ppc/ppcmmu.cpp
+++ b/cpu/ppc/ppcmmu.cpp
@@ -83,10 +83,6 @@ AddressMapEntry last_exec_area  = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullpt
 AddressMapEntry last_ptab_area  = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullptr};
 AddressMapEntry last_dma_area   = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullptr};
 
-void ppc_set_cur_instruction(const uint8_t* ptr) {
-    ppc_cur_instruction = READ_DWORD_BE_A(ptr);
-}
-
 /** 601-style block address translation. */
 static BATResult mpc601_block_address_translation(uint32_t la)
 {

--- a/cpu/ppc/ppcmmu.h
+++ b/cpu/ppc/ppcmmu.h
@@ -123,7 +123,6 @@ extern void mmu_change_mode(void);
 extern void mmu_pat_ctx_changed();
 extern void tlb_flush_entry(uint32_t ea);
 
-extern void ppc_set_cur_instruction(const uint8_t* ptr);
 extern uint64_t mem_read_dbg(uint32_t virt_addr, uint32_t size);
 uint8_t *mmu_translate_imem(uint32_t vaddr);
 

--- a/devices/video/atimach64gx.cpp
+++ b/devices/video/atimach64gx.cpp
@@ -299,7 +299,7 @@ void AtiMach64Gx::enable_crtc_internal()
     switch (this->pixel_depth) {
     case 8:
         this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
-            this->convert_frame_8bpp(dst_buf, dst_pitch);
+            this->convert_frame_8bpp_indexed(dst_buf, dst_pitch);
         };
         break;
     default:

--- a/devices/video/atirage.cpp
+++ b/devices/video/atirage.cpp
@@ -551,7 +551,7 @@ void ATIRage::crtc_update() {
             ABORT_F("%s: DAC_DIRECT set!", this->name.c_str());
         }
         this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
-            this->convert_frame_8bpp(dst_buf, dst_pitch);
+            this->convert_frame_8bpp_indexed(dst_buf, dst_pitch);
         };
         break;
     default:

--- a/devices/video/control.cpp
+++ b/devices/video/control.cpp
@@ -267,7 +267,7 @@ void ControlVideo::enable_display()
 
     if (pixel_depth == 8) {
         this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
-            this->convert_frame_8bpp(dst_buf, dst_pitch);
+            this->convert_frame_8bpp_indexed(dst_buf, dst_pitch);
         };
     } else {
         ABORT_F("Control: 16bpp and 32bpp formats not supported yet!");

--- a/devices/video/pdmonboard.cpp
+++ b/devices/video/pdmonboard.cpp
@@ -121,13 +121,13 @@ void PdmOnboardVideo::set_depth_internal(int pitch)
     switch (this->pixel_depth) {
     case 1:
         this->convert_fb_cb = [this](uint8_t* dst_buf, int dst_pitch) {
-            this->convert_frame_1bpp(dst_buf, dst_pitch);
+            this->convert_frame_1bpp_indexed(dst_buf, dst_pitch);
         };
         this->fb_pitch = pitch >> 3;    // one byte contains 8 pixels
         break;
     case 8:
         this->convert_fb_cb = [this](uint8_t* dst_buf, int dst_pitch) {
-            this->convert_frame_8bpp(dst_buf, dst_pitch);
+            this->convert_frame_8bpp_indexed(dst_buf, dst_pitch);
         };
         this->fb_pitch = pitch; // one byte contains 1 pixel
         break;
@@ -239,7 +239,7 @@ void PdmOnboardVideo::disable_video_internal()
     CLUT entry #127 (%01111111) and a black pixel to #255 (%11111111).
     It requres a non-standard conversion routine implemented below.
  */
-void PdmOnboardVideo::convert_frame_1bpp(uint8_t *dst_buf, int dst_pitch)
+void PdmOnboardVideo::convert_frame_1bpp_indexed(uint8_t *dst_buf, int dst_pitch)
 {
     uint8_t  *src_buf, *src_row, pix;
     uint32_t *dst_row;

--- a/devices/video/pdmonboard.h
+++ b/devices/video/pdmonboard.h
@@ -69,10 +69,12 @@ public:
     };
 
 protected:
-    void set_depth_internal(int pitch);
+    void set_depth_internal(int width);
     void enable_video_internal();
     void disable_video_internal();
     void convert_frame_1bpp_indexed(uint8_t *dst_buf, int dst_pitch);
+    void convert_frame_2bpp_indexed(uint8_t *dst_buf, int dst_pitch);
+    void convert_frame_4bpp_indexed(uint8_t *dst_buf, int dst_pitch);
 
 private:
     uint8_t     video_mode;

--- a/devices/video/pdmonboard.h
+++ b/devices/video/pdmonboard.h
@@ -72,7 +72,7 @@ protected:
     void set_depth_internal(int pitch);
     void enable_video_internal();
     void disable_video_internal();
-    void convert_frame_1bpp(uint8_t *dst_buf, int dst_pitch);
+    void convert_frame_1bpp_indexed(uint8_t *dst_buf, int dst_pitch);
 
 private:
     uint8_t     video_mode;

--- a/devices/video/videoctrl.cpp
+++ b/devices/video/videoctrl.cpp
@@ -136,26 +136,304 @@ void VideoCtrlBase::setup_hw_cursor(int cursor_width, int cursor_height)
     this->cursor_on = true;
 }
 
-void VideoCtrlBase::convert_frame_1bpp(uint8_t *dst_buf, int dst_pitch)
+void VideoCtrlBase::convert_frame_1bpp_indexed(uint8_t *dst_buf, int dst_pitch)
 {
-    // TODO: implement me!
-}
-
-void VideoCtrlBase::convert_frame_8bpp(uint8_t *dst_buf, int dst_pitch)
-{
-    uint8_t *src_buf, *src_row, *dst_row;
+    uint8_t *src_row, *dst_row;
     int     src_pitch;
 
-    src_buf   = this->fb_ptr;
-    src_pitch = this->fb_pitch;
+    src_pitch = this->fb_pitch - ((this->active_width + 7) >> 3);
+    dst_pitch = dst_pitch - 4 * this->active_width;
 
-    for (int h = 0; h < this->active_height; h++) {
-        src_row = &src_buf[h * src_pitch];
-        dst_row = &dst_buf[h * dst_pitch];
-
-        for (int x = 0; x < this->active_width; x++) {
-            WRITE_DWORD_LE_A(dst_row, this->palette[src_row[x]]);
+    src_row = this->fb_ptr - 1;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        uint8_t bit = 0x00;
+        uint8_t c;
+        for (int x = this->active_width; x > 0; x--) {
+            if (!bit) {
+                src_row += 1;
+                bit = 0x80;
+                c = *src_row;
+            }
+            WRITE_DWORD_LE_A(dst_row, this->palette[!!(c & bit)]);
+            bit >>= 1;
             dst_row += 4;
         }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+void VideoCtrlBase::convert_frame_2bpp_indexed(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - (this->active_width >> 2);
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        uint8_t c;
+        for (int x = this->active_width >> 2; x > 0; x--) {
+            c = *src_row;
+            WRITE_DWORD_LE_A(dst_row, this->palette[c >> 6]);
+            dst_row += 4;
+            WRITE_DWORD_LE_A(dst_row, this->palette[(c >> 4) & 3]);
+            dst_row += 4;
+            WRITE_DWORD_LE_A(dst_row, this->palette[(c >> 2) & 3]);
+            dst_row += 4;
+            WRITE_DWORD_LE_A(dst_row, this->palette[c & 3]);
+            dst_row += 4;
+            src_row += 1;
+        }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+void VideoCtrlBase::convert_frame_4bpp_indexed(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - (this->active_width >> 1);
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        uint8_t c;
+        for (int x = this->active_width >> 1; x > 0; x--) {
+            c = *src_row;
+            WRITE_DWORD_LE_A(dst_row, this->palette[c >> 4]);
+            dst_row += 4;
+            WRITE_DWORD_LE_A(dst_row, this->palette[c & 15]);
+            dst_row += 4;
+            src_row += 1;
+        }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+void VideoCtrlBase::convert_frame_8bpp_indexed(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width; x > 0; x--) {
+            WRITE_DWORD_LE_A(dst_row, this->palette[*src_row++]);
+            dst_row += 4;
+        }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+#if 0
+// alternative version to the above but only works for little endian host
+void VideoCtrlBase::convert_frame_8bpp_32LE_indexed(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *dst_row;
+    uint32_t *src_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = (uint32_t*)this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width >> 2; x > 0; x--) {
+            uint32_t pixels = *src_row++;
+            WRITE_DWORD_LE_A(dst_row     , this->palette[(uint8_t)(pixels      )]);
+            WRITE_DWORD_LE_A(dst_row +  4, this->palette[(uint8_t)(pixels >>  8)]);
+            WRITE_DWORD_LE_A(dst_row +  8, this->palette[(uint8_t)(pixels >> 16)]);
+            WRITE_DWORD_LE_A(dst_row + 12, this->palette[(uint8_t)(pixels >> 24)]);
+            dst_row += 16;
+        }
+        src_row = (uint32_t*)((uint8_t*)src_row + src_pitch);
+        dst_row += dst_pitch;
+    }
+}
+#endif
+
+// RGB332
+void VideoCtrlBase::convert_frame_8bpp(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width; x > 0; x--) {
+            uint32_t c = *src_row++;
+            uint32_t r = ((c << 16) & 0x00E00000) | ((c << 13) & 0x001C0000) | ((c << 10) & 0x00030000);
+            uint32_t g = ((c << 11) & 0x0000E000) | ((c <<  8) & 0x00001C00) | ((c <<  5) & 0x00000300);
+            uint32_t b = ((c <<  6) & 0x000000C0) | ((c <<  4) & 0x00000030) | ((c <<  2) & 0x0000000C) | (c & 0x00000003);
+            WRITE_DWORD_LE_A(dst_row, r | g | b);
+            dst_row += 4;
+        }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+// RGB555
+void VideoCtrlBase::convert_frame_15bpp(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - 2 * this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width; x > 0; x--) {
+            uint32_t c = *((uint16_t*)(src_row));
+            uint32_t r = ((c << 9) & 0x00F80000) | ((c << 4) & 0x00070000);
+            uint32_t g = ((c << 6) & 0x0000F800) | ((c << 1) & 0x00000700);
+            uint32_t b = ((c << 3) & 0x000000F8) | ((c >> 2) & 0x00000007);
+            WRITE_DWORD_LE_A(dst_row, r | g | b);
+            src_row += 2;
+            dst_row += 4;
+        }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+// RGB555_BE
+void VideoCtrlBase::convert_frame_15bpp_BE(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - 2 * this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width; x > 0; x--) {
+            uint32_t c = READ_WORD_BE_A(src_row);
+            uint32_t r = ((c << 9) & 0x00F80000) | ((c << 4) & 0x00070000);
+            uint32_t g = ((c << 6) & 0x0000F800) | ((c << 1) & 0x00000700);
+            uint32_t b = ((c << 3) & 0x000000F8) | ((c >> 2) & 0x00000007);
+            WRITE_DWORD_LE_A(dst_row, r | g | b);
+            src_row += 2;
+            dst_row += 4;
+        }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+// RGB565
+void VideoCtrlBase::convert_frame_16bpp(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - 2 * this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width; x > 0; x--) {
+            uint32_t c = *((uint16_t*)(src_row));
+            uint32_t r = ((c << 8) & 0x00F80000) | ((c << 3) & 0x00070000);
+            uint32_t g = ((c << 5) & 0x0000FC00) | ((c >> 1) & 0x00000300);
+            uint32_t b = ((c << 3) & 0x000000F8) | ((c >> 2) & 0x00000007);
+            WRITE_DWORD_LE_A(dst_row, r | g | b);
+            src_row += 2;
+            dst_row += 4;
+        }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+// RGB888
+void VideoCtrlBase::convert_frame_24bpp(uint8_t *dst_buf, int dst_pitch)
+{
+    uint8_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - 3 * this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = this->fb_ptr;
+    dst_row = dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width; x > 0; x--) {
+            uint32_t c = (src_row[0] << 16) | (src_row[1] << 8) | src_row[2];
+            WRITE_DWORD_LE_A(dst_row, c);
+            src_row += 3;
+            dst_row += 4;
+        }
+        src_row += src_pitch;
+        dst_row += dst_pitch;
+    }
+}
+
+// ARGB8888
+void VideoCtrlBase::convert_frame_32bpp(uint8_t *dst_buf, int dst_pitch)
+{
+    uint32_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - 4 * this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = (uint32_t*)this->fb_ptr;
+    dst_row = (uint32_t*)dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width; x > 0; x--) {
+            uint32_t c = READ_DWORD_LE_A(src_row);
+            WRITE_DWORD_LE_A(dst_row, c);
+            src_row++;
+            dst_row++;
+        }
+        src_row = (uint32_t*)((uint8_t*)src_row + src_pitch);
+        dst_row = (uint32_t*)((uint8_t*)dst_row + dst_pitch);
+    }
+}
+
+// ARGB8888_BE
+void VideoCtrlBase::convert_frame_32bpp_BE(uint8_t *dst_buf, int dst_pitch)
+{
+    uint32_t *src_row, *dst_row;
+    int     src_pitch;
+
+    src_pitch = this->fb_pitch - 4 * this->active_width;
+    dst_pitch = dst_pitch - 4 * this->active_width;
+
+    src_row = (uint32_t*)this->fb_ptr;
+    dst_row = (uint32_t*)dst_buf;
+    for (int h = this->active_height; h > 0; h--) {
+        for (int x = this->active_width; x > 0; x--) {
+            uint32_t c = READ_DWORD_BE_A(src_row);
+            WRITE_DWORD_LE_A(dst_row, c);
+            src_row++;
+            dst_row++;
+        }
+        src_row = (uint32_t*)((uint8_t*)src_row + src_pitch);
+        dst_row = (uint32_t*)((uint8_t*)dst_row + dst_pitch);
     }
 }

--- a/devices/video/videoctrl.h
+++ b/devices/video/videoctrl.h
@@ -55,8 +55,20 @@ public:
     virtual void get_cursor_position(int& x, int& y) { x = 0; y = 0; };
 
     // converters for various framebuffer pixel depths
-    virtual void convert_frame_1bpp(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_1bpp_indexed(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_2bpp_indexed(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_4bpp_indexed(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_8bpp_indexed(uint8_t *dst_buf, int dst_pitch);
+#if 0
+    virtual void convert_frame_8bpp_32LE_indexed(uint8_t *dst_buf, int dst_pitch);
+#endif
     virtual void convert_frame_8bpp(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_15bpp(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_15bpp_BE(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_16bpp(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_24bpp(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_32bpp(uint8_t *dst_buf, int dst_pitch);
+    virtual void convert_frame_32bpp_BE(uint8_t *dst_buf, int dst_pitch);
 
 protected:
     // CRT controller parameters
@@ -76,8 +88,8 @@ protected:
     uint32_t    palette[256]; // internal DAC palette in RGBA format
 
     // Framebuffer parameters
-    uint8_t*    fb_ptr;
-    int         fb_pitch;
+    uint8_t*    fb_ptr = nullptr;
+    int         fb_pitch = 0;
     uint32_t    refresh_task_id = 0;
     uint32_t    vbl_end_task_id = 0;
 


### PR DESCRIPTION
Upstreams @joevt's joevt/dingusppc@1d56fc73298dca1773cf8815a90cf3ff04c0f0b and joevt/dingusppc@da600dd6af076dcf2068e82e6a1b7c89192ccaa7 to pick up improved color depth support for PDM video.

@joevt: hope you don't mind -- I wanted these in my fork, and rather than increasing the divergence with upstream, I figured it was best for all parties if this was integrated, since they cherrypick cleanly.