### PR TITLE
Add support for more ATI Rage video modes

### DIFF
--- a/devices/video/atirage.cpp
+++ b/devices/video/atirage.cpp
@@ -546,16 +546,45 @@ void ATIRage::crtc_update() {
     int pix_fmt = extract_bits<uint32_t>(this->regs[ATI_CRTC_GEN_CNTL], 8, 3);
 
     switch (pix_fmt) {
+        case 1:
+        this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
+            this->convert_frame_4bpp_indexed(dst_buf, dst_pitch);
+        };
+        break;
     case 2:
         if (bit_set(this->regs[ATI_DAC_CNTL], 10)) {
-            ABORT_F("%s: DAC_DIRECT set!", this->name.c_str());
+            this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
+                this->convert_frame_8bpp(dst_buf, dst_pitch);
+            };
         }
+        else {
+            this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
+                this->convert_frame_8bpp_indexed(dst_buf, dst_pitch);
+            };
+        }
+        break;
+    case 3:
         this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
-            this->convert_frame_8bpp_indexed(dst_buf, dst_pitch);
+            this->convert_frame_15bpp(dst_buf, dst_pitch);
+        };
+        break;
+    case 4:
+        this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
+            this->convert_frame_16bpp(dst_buf, dst_pitch);
+        };
+        break;
+    case 5:
+        this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
+            this->convert_frame_24bpp(dst_buf, dst_pitch);
+        };
+        break;
+    case 6:
+        this->convert_fb_cb = [this](uint8_t *dst_buf, int dst_pitch) {
+            this->convert_frame_32bpp(dst_buf, dst_pitch);
         };
         break;
     default:
-        ABORT_F("%s: unsupported pixel format %d", this->name.c_str(), pix_fmt);
+        LOG_F(ERROR, "%s: unsupported pixel format %d", this->name.c_str(), pix_fmt);
     }
 
     LOG_F(INFO, "%s: primary CRT controller enabled:", this->name.c_str());


### PR DESCRIPTION
Cherrypicks a small piece of joevt/dingusppc@117ca1e4494ced009323ef6977858cfe10aefb95 so that booting from the 10.2 CD gets past it trying to change the video mode to 15bpp.