### PR TITLE
Add basic support for the extended ADB mouse protocol.

### DIFF
--- a/devices/common/adb/adbmouse.cpp
+++ b/devices/common/adb/adbmouse.cpp
@@ -88,6 +88,22 @@ bool AdbMouse::get_register_0() {
     return false;
 }
 
+bool AdbMouse::get_register_1() {
+    uint8_t* out_buf = this->host_obj->get_output_buf();
+    // Identifier
+    out_buf[0] = 'a';
+    out_buf[1] = 'p';
+    out_buf[2] = 'p';
+    out_buf[3] = 'l';
+    // Slightly higher resolution of 300 units per inch
+    out_buf[4] = 300 >> 8;
+    out_buf[5] = 300 & 0xFF;
+    out_buf[6] = 1; // mouse
+    out_buf[7] = 1; // 1 button
+    this->host_obj->set_output_count(8);
+    return true;
+}
+
 void AdbMouse::set_register_3() {
     if (this->host_obj->get_input_count() < 2) // ensure we got enough data
         return;
@@ -101,9 +117,8 @@ void AdbMouse::set_register_3() {
         break;
     case 1:
     case 2:
+    case 4: // switch over to extended mouse protocol
         this->dev_handler_id = in_data[1];
-        break;
-    case 4: // extended mouse protocol isn't supported yet
         break;
     case 0xFE: // move to a new address if there was no collision
         if (!this->got_collision) {

--- a/devices/common/adb/adbmouse.h
+++ b/devices/common/adb/adbmouse.h
@@ -45,6 +45,7 @@ public:
     void event_handler(const MouseEvent& event);
 
     bool get_register_0() override;
+    bool get_register_1() override;
     void set_register_3() override;
 
 private:


### PR DESCRIPTION
We now respond to the switch to device handler ID 4 and the register 1 read (as described by https://developer.apple.com/library/archive/technotes/hw/hw_01.html#Extended).

We don't yet use the extra precision bits in the register 0.