### PR TITLE
machinepdm: fix machine ID

### DIFF
--- a/devices/common/machineid.h
+++ b/devices/common/machineid.h
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/ioctrl/macio.h>
 
 #include <cinttypes>
+#include <loguru.hpp>
 #include <string>
 
 /**
@@ -58,7 +59,14 @@ public:
     ~NubusMacID() = default;
 
     uint32_t read(uint32_t rgn_start, uint32_t offset, int size) {
-        return (offset < 4 ? this->id[offset] : 0);
+        if (size == 4 && offset == 0) {
+            return *(uint32_t*)this->id;
+        }
+        if (size == 1 && offset < 4) {
+            return this->id[offset];
+        }
+        ABORT_F("NubusMacID: invalid read size %d, offset %d!", size, offset);
+        return 0;
     };
 
     /* not writable */

--- a/machines/machinepdm.cpp
+++ b/machines/machinepdm.cpp
@@ -50,7 +50,7 @@ int initialize_pdm(std::string& id)
     HMC* hmc_obj = dynamic_cast<HMC*>(gMachineObj->get_comp_by_name("HMC"));
 
     if (id == "pm6100") {
-        machine_id = 0x3010;
+        machine_id = 0x3011;
     } else if (id == "pm7100") {
         machine_id = 0x3012;
     } else if (id == "pm8100") {


### PR DESCRIPTION
Handle 4 byte reads from the machine ID MMIO region. Also change the 6100 machine ID to match the one used by MAME.