### PR TITLE
Ensure that NVRAM is persisted when exiting the debugger after an abort

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -176,7 +176,8 @@ int main(int argc, char** argv) {
         power_off_reason = po_enter_debugger;
         enter_debugger();
 
-        abort();
+        // Ensure that NVRAM and other state is persisted before we terminate.
+        delete gMachineObj.release();
     });
 
     // redirect SIGINT to our own handler


### PR DESCRIPTION
The `SIGABRT` handler is not invoked by the abort() call in the loguru fatal handler, but either way it's not necessary (it does its own `abort()`).

Switch to explicitly cleaning up the machine object, which as a side effect in the destructor chain will persist the NVRAM.