### PR TITLE
bandit: Fix regression in non-Aspen PCI bridge

### DIFF
--- a/devices/common/pci/bandit.cpp
+++ b/devices/common/pci/bandit.cpp
@@ -193,10 +193,7 @@ void BanditHost::write(uint32_t rgn_start, uint32_t offset, uint32_t value, int 
         break;
 
     case 2: // CONFIG_ADDR
-        if (this->is_aspen)
-            this->config_addr = value;
-        else
-            BYTESWAP_32(value);
+        this->config_addr = (this->is_aspen) ? value : BYTESWAP_32(value);
         break;
 
     default: // I/O space


### PR DESCRIPTION
Refactor from e7da98b6bddbce0208d890ba23ed55d07d05b119 accidentally made the non-Aspen PCI code path for `CONFIG_ADDR` writes by a no-op.