### PR TITLE
Add instruction counters to CPU profiler

### DIFF
--- a/utils/profiler.h
+++ b/utils/profiler.h
@@ -31,13 +31,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
-enum class ProfileVarFmt { DEC, HEX };
+enum class ProfileVarFmt { DEC, HEX, COUNT };
 
 /** Define a special data type for profile variables. */
 typedef struct ProfileVar {
     std::string     name;
     ProfileVarFmt   format;
     uint64_t        value;
+    uint64_t        count_total;
 } ProfileVar;
 
 /** Base class for user-defined profiles. */


### PR DESCRIPTION
Keeps track of instructions (including operands) that are executed, to see if there are any hotspots that could be optimized or fastpaths that should be added.

Also adds a mode where CPU profiler data is periodically output, to make it easier to get at these instruction counts during startup.