### PR TITLE
debugger: Gracefully exit upon EOF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out/
 
 # Ignore compiled object files
 .vs/
+.vscode/
 *.o
 *.d
 

--- a/debugger/debugger.cpp
+++ b/debugger/debugger.cpp
@@ -459,7 +459,7 @@ void enter_debugger() {
     ioctl(0, TIOCGWINSZ, &win_size_previous);
 #endif
 
-    while (1) {
+    while (!feof(stdin)) {
         if (power_off_reason == po_shut_down) {
             power_off_reason = po_shutting_down;
             break;

--- a/endianswap.h
+++ b/endianswap.h
@@ -28,12 +28,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef ENDIAN_SWAP_H
 #define ENDIAN_SWAP_H
 
+//Shamelessly taken from an endian detection routine written by lovell and Arritmic
+//(See: https://github.com/Arritmic/farmhash/blob/master/src/farmhash.h)
+
 #ifdef __GNUG__ /* GCC, ICC and Clang */
 
 #   ifdef __APPLE__
 #       include <machine/endian.h>
-#   else
+#   elif defined(__linux__) || defined(__CYGWIN__) || defined( __GNUC__ ) && !defined(_WIN32) || defined( __GNU_LIBRARY__ )
 #       include <endian.h>
+#   elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__s390x__)
+#       include <sys/endian.h>
 #   endif
 
 #   define BYTESWAP_16(x) (__builtin_bswap16 (x))

--- a/endianswap.h
+++ b/endianswap.h
@@ -28,13 +28,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef ENDIAN_SWAP_H
 #define ENDIAN_SWAP_H
 
-//Shamelessly taken from an endian detection routine written by lovell and Arritmic
+//Partially inspired by an endian detection routine written by lovell and Arritmic
 //(See: https://github.com/Arritmic/farmhash/blob/master/src/farmhash.h)
 
 #ifdef __GNUG__ /* GCC, ICC and Clang */
 
 #   ifdef __APPLE__
 #       include <machine/endian.h>
+#   elif defined(__clang__) && defined(_WIN32)
+#       include <endian.h>
 #   elif defined(__linux__) || defined(__CYGWIN__) || defined( __GNUC__ ) && !defined(_WIN32) || defined( __GNU_LIBRARY__ )
 #       include <endian.h>
 #   elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__s390x__)

--- a/machines/machinepdm.cpp
+++ b/machines/machinepdm.cpp
@@ -90,7 +90,7 @@ int initialize_pdm(std::string& id)
     }
 
     // Init virtual CPU and request MPC601
-    ppc_cpu_init(hmc_obj, PPC_VER::MPC601, true, 7812500ULL);
+    ppc_cpu_init(hmc_obj, PPC_VER::MPC601, true, 7833600ULL);
 
     return 0;
 }

--- a/utils/profiler.h
+++ b/utils/profiler.h
@@ -31,13 +31,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
-enum class ProfileVarFmt { DEC, HEX };
+enum class ProfileVarFmt { DEC, HEX, COUNT };
 
 /** Define a special data type for profile variables. */
 typedef struct ProfileVar {
     std::string     name;
     ProfileVarFmt   format;
     uint64_t        value;
+    uint64_t        count_total;
 } ProfileVar;
 
 /** Base class for user-defined profiles. */


### PR DESCRIPTION
Typing "quit" isn't the only way to leave the REPL. This change prevents the REPL from spiralling in an endless loop when you hit ^D in the terminal.

Maybe there's a more C++-esque way of expressing what I'm trying to do here -- it works as expected on Linux, at least.