### PR TITLE
Fix missing std::find_if and others with GCC 14.1.1

### DIFF
--- a/cpu/ppc/ppcdisasm.cpp
+++ b/cpu/ppc/ppcdisasm.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define _CRT_SECURE_NO_WARNINGS /* shut up MSVC regarding the unsafe strcpy/strcat */
 
 #include "ppcdisasm.h"
+#include <algorithm>
 #include <cstring>
 #include <functional> /* without this, MSVC doesn't understand std::function */
 #include <iostream>

--- a/devices/memctrl/mpc106.cpp
+++ b/devices/memctrl/mpc106.cpp
@@ -28,6 +28,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/memctrl/mpc106.h>
 #include <loguru.hpp>
 
+#include <algorithm>
 #include <cinttypes>
 #include <cstring>
 #include <string>


### PR DESCRIPTION
Had issues compiling this with GCC 14.1.1 (20240618) on `ppc64le`.

Adding two includes fixed it however.