### PR TITLE
Fix keyboard event bug where mouse grab combination won't work if SDL_GetModState

### DIFF
--- a/core/hostevents_sdl.cpp
+++ b/core/hostevents_sdl.cpp
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/common/adb/adbkeyboard.h>
 #include <loguru.hpp>
 #include <SDL.h>
-
+#include <stdio.h>
 EventManager* EventManager::event_manager;
 
 static int get_sdl_event_key_code(const SDL_KeyboardEvent &event);
@@ -56,7 +56,7 @@ void EventManager::poll_events()
         case SDL_KEYUP: {
                 // Internal shortcuts to trigger mouse grab, intentionally not
                 // sent to the host.
-                if (event.key.keysym.sym == SDLK_g && SDL_GetModState() == KMOD_LCTRL) {
+            if (SDL_GetModState() & KMOD_LCTRL && event.key.keysym.sym == SDLK_g) {
                     if (event.type == SDL_KEYUP) {
                         toggle_mouse_grab(event.key);
                     }

--- a/core/hostevents_sdl.cpp
+++ b/core/hostevents_sdl.cpp
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <devices/common/adb/adbkeyboard.h>
 #include <loguru.hpp>
 #include <SDL.h>
-#include <stdio.h>
+
 EventManager* EventManager::event_manager;
 
 static int get_sdl_event_key_code(const SDL_KeyboardEvent &event);
@@ -56,7 +56,7 @@ void EventManager::poll_events()
         case SDL_KEYUP: {
                 // Internal shortcuts to trigger mouse grab, intentionally not
                 // sent to the host.
-            if (SDL_GetModState() & KMOD_LCTRL && event.key.keysym.sym == SDLK_g) {
+                if (SDL_GetModState() & KMOD_LCTRL && event.key.keysym.sym == SDLK_g) {
                     if (event.type == SDL_KEYUP) {
                         toggle_mouse_grab(event.key);
                     }


### PR DESCRIPTION
I found this bug while trying to figure out why dingus won't work when compiled with MSVC (I still had to use Clang when compiling w/ vs2022).

Basically when the keyboard is in a specific state (NumLock, CapsLock, etc.) the code below:
```
if ( event.key.keysym.sym == SDLK_g && SDL_GetModState() == KMOD_LCTRL) {
    if (event.type == SDL_KEYUP) {
        toggle_mouse_grab(event.key);
    }
    return;
}
```

doesn't work because since if the keyboard is in a specific state, it returns the OR'd combination of said modifier, in this case CTRL, which has a value of 0x40, with the state of the keyboard.

So if the keyboard has all locks disabled, `SDL_GetModState()` returns the value of 0 | 0x40. But if NumLock is enabled, it returns the value of `0x1000 | 0x40` or `0x2000 | 0x40` if caps lock is enabled, meaning `SDL_GetModState() == KMOD_LCTRL` never gets evaluated to true if CTRL+G is pressed as it erroneously gets evaluated to `0x1040 == 0x40` if the combination is pressed if numlock is enabled, or `0x2040 == 0x40` if capslock is enabled.

The solution involves getting the mask of `SDL_GetModState()` and `KMOD_LCTRL` so that the expression  `SDL_GetModState() == KMOD_LCTRL` can be checked properly regardless if the keyboard has any combination of caps lock/numlock enabled.

```
if (SDL_GetModState() & KMOD_LCTRL && event.key.keysym.sym == SDLK_g) {
    if (event.type == SDL_KEYUP) {
        toggle_mouse_grab(event.key);
    }
    return;
}
```

This was the reference I used to fix the issue:
https://stackoverflow.com/questions/48706762/sdl-2-how-to-check-for-no-modifiers-keyboard-input