### PR TITLE
Do not test for equality when checking if ctrl is pressed.

### DIFF
--- a/core/hostevents_sdl.cpp
+++ b/core/hostevents_sdl.cpp
@@ -56,7 +56,7 @@ void EventManager::poll_events()
         case SDL_KEYUP: {
                 // Internal shortcuts to trigger mouse grab, intentionally not
                 // sent to the host.
-                if (event.key.keysym.sym == SDLK_g && ((SDL_GetModState() & KMOD_LCTRL) == KMOD_CTRL)) {
+                if (event.key.keysym.sym == SDLK_g && SDL_GetModState() & KMOD_LCTRL) {
                     if (event.type == SDL_KEYUP) {
                         toggle_mouse_grab(event.key);
                     }


### PR DESCRIPTION
The initial change I committed worked fine before.