### PR TITLE
Switch ImgFile to using uint64_t explicitly

### DIFF
--- a/utils/imgfile.h
+++ b/utils/imgfile.h
@@ -37,10 +37,10 @@ public:
     bool open(const std::string& img_path);
     void close();
 
-    size_t size() const;
+    uint64_t size() const;
 
-    size_t read(void* buf, off_t offset, size_t length) const;
-    size_t write(const void* buf, off_t offset, size_t length);
+    uint64_t read(void* buf, uint64_t offset, uint64_t length) const;
+    uint64_t write(const void* buf, uint64_t offset, uint64_t length);
 private:
     class Impl; // Holds private fields
     std::unique_ptr<Impl> impl;

--- a/utils/imgfile_sdl.cpp
+++ b/utils/imgfile_sdl.cpp
@@ -46,20 +46,20 @@ void ImgFile::close()
     impl->stream.close();
 }
 
-size_t ImgFile::size() const
+uint64_t ImgFile::size() const
 {
     impl->stream.seekg(0, impl->stream.end);
     return impl->stream.tellg();
 }
 
-size_t ImgFile::read(void* buf, off_t offset, size_t length) const
+uint64_t ImgFile::read(void* buf, uint64_t offset, uint64_t length) const
 {
     impl->stream.seekg(offset, std::ios::beg);
     impl->stream.read((char *)buf, length);
     return impl->stream.gcount();
 }
 
-size_t ImgFile::write(const void* buf, off_t offset, size_t length)
+uint64_t ImgFile::write(const void* buf, uint64_t offset, uint64_t length)
 {
     impl->stream.seekg(offset, std::ios::beg);
     impl->stream.write((const char *)buf, length);


### PR DESCRIPTION
`size_t` and `off_t` are 32-bit values in Emscripten, which causes issues with disk images larger than 4GB. Use the explicit type (which is more consistent with the rest of the codebase anyway).