### PR TITLE
sdl: handle SDL_WINDOWEVENT_EXPOSED event to fix redrawing issue

### DIFF
--- a/devices/video/display_sdl.cpp
+++ b/devices/video/display_sdl.cpp
@@ -97,6 +97,9 @@ void Display::handle_events(const WindowEvent& wnd_event) {
     if (wnd_event.sub_type == SDL_WINDOWEVENT_SIZE_CHANGED &&
         wnd_event.window_id == impl->disp_wnd_id)
         impl->resizing = false;
+    if (wnd_event.sub_type == SDL_WINDOWEVENT_EXPOSED &&
+        wnd_event.window_id == impl->disp_wnd_id)
+        SDL_RenderPresent(impl->renderer);
 }
 
 void Display::blank() {


### PR DESCRIPTION
without this, SDL window can act like a "hang" window unless there is update(s) from emulated context.