### PR TITLE
atapibasedevice: fix unaligned memory access

### DIFF
--- a/devices/common/ata/atabasedevice.h
+++ b/devices/common/ata/atabasedevice.h
@@ -96,6 +96,7 @@ protected:
 
     uint16_t    *data_ptr       = nullptr;
     uint16_t    *cur_data_ptr   = nullptr;
+    alignas(uint16_t)
     uint8_t     data_buf[512]   = {};
     int         xfer_cnt        = 0;
     int         chunk_cnt       = 0;

--- a/devices/common/ata/atapibasedevice.h
+++ b/devices/common/ata/atapibasedevice.h
@@ -55,6 +55,7 @@ protected:
     uint16_t    r_byte_count;
     bool        status_expected = false;
 
+    alignas(uint16_t)
     uint8_t     cmd_pkt[12] = {};
 };
 


### PR DESCRIPTION
Both `cmd_pkt` and `data_buf` class members are cast to a `uint16_t` pointer, so we need to make sure they are properly aligned, otherwise it is undefined behavior.