### PR TITLE
ppc: make ppc_effective_address into a local

### DIFF
--- a/cpu/ppc/poweropcodes.cpp
+++ b/cpu/ppc/poweropcodes.cpp
@@ -200,7 +200,7 @@ void dppc_interpreter::power_dozi() {
 template <field_rc rec>
 void dppc_interpreter::power_lscbx() {
     ppc_grab_regsdab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
 
     uint32_t bytes_to_load = (ppc_state.spr[SPR::XER] & 0x7F);
     uint32_t bytes_remaining = bytes_to_load;

--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -303,8 +303,6 @@ extern unsigned exec_flags;
 
 extern jmp_buf exc_env;
 
-extern bool grab_return;
-
 enum Po_Cause : int {
     po_none,
     po_starting_up,

--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -330,7 +330,6 @@ extern bool is_64bit;      // For PowerPC G5 Emulation
 
 // Important Addressing Integers
 extern uint32_t ppc_cur_instruction;
-extern uint32_t ppc_effective_address;
 extern uint32_t ppc_next_instruction_address;
 
 inline void ppc_set_cur_instruction(const uint8_t* ptr) {

--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -66,7 +66,6 @@ bool grab_return;
 bool grab_breakpoint;
 
 uint32_t ppc_cur_instruction;    // Current instruction for the PPC
-uint32_t ppc_effective_address;
 uint32_t ppc_next_instruction_address;    // Used for branching, setting up the NIA
 
 unsigned exec_flags; // execution control flags

--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -62,9 +62,6 @@ Po_Cause power_off_reason = po_enter_debugger;
 
 SetPRS ppc_state;
 
-bool grab_return;
-bool grab_breakpoint;
-
 uint32_t ppc_cur_instruction;    // Current instruction for the PPC
 uint32_t ppc_next_instruction_address;    // Used for branching, setting up the NIA
 

--- a/cpu/ppc/ppcfpopcodes.cpp
+++ b/cpu/ppc/ppcfpopcodes.cpp
@@ -664,7 +664,7 @@ template void dppc_interpreter::ppc_fctiwz<RC1>();
 
 void dppc_interpreter::ppc_lfs() {
     ppc_grab_regsfpdia(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += (reg_a) ? val_reg_a : 0;
     uint32_t result = mmu_read_vmem<uint32_t>(ppc_effective_address);
     ppc_state.fpr[reg_d].dbl64_r = *(float*)(&result);
@@ -673,7 +673,7 @@ void dppc_interpreter::ppc_lfs() {
 void dppc_interpreter::ppc_lfsu() {
     ppc_grab_regsfpdia(ppc_cur_instruction);
     if (reg_a) {
-        ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+        uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
         ppc_effective_address += (reg_a) ? val_reg_a : 0;
         uint32_t result = mmu_read_vmem<uint32_t>(ppc_effective_address);
         ppc_state.fpr[reg_d].dbl64_r = *(float*)(&result);
@@ -685,7 +685,7 @@ void dppc_interpreter::ppc_lfsu() {
 
 void dppc_interpreter::ppc_lfsx() {
     ppc_grab_regsfpdiab(ppc_cur_instruction);
-    ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
+    uint32_t ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
     uint32_t result       = mmu_read_vmem<uint32_t>(ppc_effective_address);
     ppc_state.fpr[reg_d].dbl64_r = *(float*)(&result);
 }
@@ -693,7 +693,7 @@ void dppc_interpreter::ppc_lfsx() {
 void dppc_interpreter::ppc_lfsux() {
     ppc_grab_regsfpdiab(ppc_cur_instruction);
     if (reg_a) {
-        ppc_effective_address = val_reg_a + val_reg_b;
+        uint32_t ppc_effective_address = val_reg_a + val_reg_b;
         uint32_t result = mmu_read_vmem<uint32_t>(ppc_effective_address);
         ppc_state.fpr[reg_d].dbl64_r = *(float*)(&result);
         ppc_state.gpr[reg_a] = ppc_effective_address;
@@ -704,7 +704,7 @@ void dppc_interpreter::ppc_lfsux() {
 
 void dppc_interpreter::ppc_lfd() {
     ppc_grab_regsfpdia(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += (reg_a) ? val_reg_a : 0;
     uint64_t ppc_result64_d = mmu_read_vmem<uint64_t>(ppc_effective_address);
     ppc_store_dfpresult_int(reg_d, ppc_result64_d);
@@ -713,7 +713,7 @@ void dppc_interpreter::ppc_lfd() {
 void dppc_interpreter::ppc_lfdu() {
     ppc_grab_regsfpdia(ppc_cur_instruction);
     if (reg_a != 0) {
-        ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+        uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
         ppc_effective_address += val_reg_a;
         uint64_t ppc_result64_d = mmu_read_vmem<uint64_t>(ppc_effective_address);
         ppc_store_dfpresult_int(reg_d, ppc_result64_d);
@@ -725,7 +725,7 @@ void dppc_interpreter::ppc_lfdu() {
 
 void dppc_interpreter::ppc_lfdx() {
     ppc_grab_regsfpdiab(ppc_cur_instruction);
-    ppc_effective_address   = val_reg_b + (reg_a ? val_reg_a : 0);
+    uint32_t ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
     uint64_t ppc_result64_d = mmu_read_vmem<uint64_t>(ppc_effective_address);
     ppc_store_dfpresult_int(reg_d, ppc_result64_d);
 }
@@ -733,7 +733,7 @@ void dppc_interpreter::ppc_lfdx() {
 void dppc_interpreter::ppc_lfdux() {
     ppc_grab_regsfpdiab(ppc_cur_instruction);
     if (reg_a) {
-        ppc_effective_address = val_reg_a + val_reg_b;
+        uint32_t ppc_effective_address = val_reg_a + val_reg_b;
         uint64_t ppc_result64_d = mmu_read_vmem<uint64_t>(ppc_effective_address);
         ppc_store_dfpresult_int(reg_d, ppc_result64_d);
         ppc_state.gpr[reg_a] = ppc_effective_address;
@@ -744,7 +744,7 @@ void dppc_interpreter::ppc_lfdux() {
 
 void dppc_interpreter::ppc_stfs() {
     ppc_grab_regsfpsia(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += (reg_a) ? val_reg_a : 0;
     float result = ppc_state.fpr[reg_s].dbl64_r;
     mmu_write_vmem<uint32_t>(ppc_effective_address, *(uint32_t*)(&result));
@@ -753,7 +753,7 @@ void dppc_interpreter::ppc_stfs() {
 void dppc_interpreter::ppc_stfsu() {
     ppc_grab_regsfpsia(ppc_cur_instruction);
     if (reg_a != 0) {
-        ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+        uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
         ppc_effective_address += val_reg_a;
         float result = ppc_state.fpr[reg_s].dbl64_r;
         mmu_write_vmem<uint32_t>(ppc_effective_address, *(uint32_t*)(&result));
@@ -765,7 +765,7 @@ void dppc_interpreter::ppc_stfsu() {
 
 void dppc_interpreter::ppc_stfsx() {
     ppc_grab_regsfpsiab(ppc_cur_instruction);
-    ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
+    uint32_t ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
     float result = ppc_state.fpr[reg_s].dbl64_r;
     mmu_write_vmem<uint32_t>(ppc_effective_address, *(uint32_t*)(&result));
 }
@@ -773,7 +773,7 @@ void dppc_interpreter::ppc_stfsx() {
 void dppc_interpreter::ppc_stfsux() {
     ppc_grab_regsfpsiab(ppc_cur_instruction);
     if (reg_a) {
-        ppc_effective_address = val_reg_a + val_reg_b;
+        uint32_t ppc_effective_address = val_reg_a + val_reg_b;
         float result = ppc_state.fpr[reg_s].dbl64_r;
         mmu_write_vmem<uint32_t>(ppc_effective_address, *(uint32_t*)(&result));
         ppc_state.gpr[reg_a] = ppc_effective_address;
@@ -784,7 +784,7 @@ void dppc_interpreter::ppc_stfsux() {
 
 void dppc_interpreter::ppc_stfd() {
     ppc_grab_regsfpsia(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += reg_a ? val_reg_a : 0;
     mmu_write_vmem<uint64_t>(ppc_effective_address, ppc_state.fpr[reg_s].int64_r);
 }
@@ -792,7 +792,7 @@ void dppc_interpreter::ppc_stfd() {
 void dppc_interpreter::ppc_stfdu() {
     ppc_grab_regsfpsia(ppc_cur_instruction);
     if (reg_a != 0) {
-        ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+        uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
         ppc_effective_address += val_reg_a;
         mmu_write_vmem<uint64_t>(ppc_effective_address, ppc_state.fpr[reg_s].int64_r);
         ppc_state.gpr[reg_a] = ppc_effective_address;
@@ -803,14 +803,14 @@ void dppc_interpreter::ppc_stfdu() {
 
 void dppc_interpreter::ppc_stfdx() {
     ppc_grab_regsfpsiab(ppc_cur_instruction);
-    ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
+    uint32_t ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
     mmu_write_vmem<uint64_t>(ppc_effective_address, ppc_state.fpr[reg_s].int64_r);
 }
 
 void dppc_interpreter::ppc_stfdux() {
     ppc_grab_regsfpsiab(ppc_cur_instruction);
     if (reg_a != 0) {
-        ppc_effective_address = val_reg_a + val_reg_b;
+        uint32_t ppc_effective_address = val_reg_a + val_reg_b;
         mmu_write_vmem<uint64_t>(ppc_effective_address, ppc_state.fpr[reg_s].int64_r);
         ppc_state.gpr[reg_a] = ppc_effective_address;
     } else {
@@ -820,7 +820,7 @@ void dppc_interpreter::ppc_stfdux() {
 
 void dppc_interpreter::ppc_stfiwx() {
     ppc_grab_regsfpsiab(ppc_cur_instruction);
-    ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
+    uint32_t ppc_effective_address = val_reg_b + (reg_a ? val_reg_a : 0);
     mmu_write_vmem<uint32_t>(ppc_effective_address, uint32_t(ppc_state.fpr[reg_s].int64_r));
 }
 

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -1395,7 +1395,6 @@ void dppc_interpreter::ppc_rfi() {
 
     mmu_change_mode();
 
-    grab_return = true;
     exec_flags = EXEF_RFI;
 }
 

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -1473,7 +1473,7 @@ void dppc_interpreter::ppc_dcbtst() {
 
 void dppc_interpreter::ppc_dcbz() {
     ppc_grab_regsab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
 
     ppc_effective_address &= 0xFFFFFFE0UL; // align EA on a 32-byte boundary
 
@@ -1494,7 +1494,7 @@ void dppc_interpreter::ppc_st() {
     num_int_stores++;
 #endif
     ppc_grab_regssa(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += reg_a ? ppc_result_a : 0;
     mmu_write_vmem<T>(ppc_effective_address, ppc_result_d);
 }
@@ -1509,7 +1509,7 @@ void dppc_interpreter::ppc_stx() {
     num_int_stores++;
 #endif
     ppc_grab_regssab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
     mmu_write_vmem<T>(ppc_effective_address, ppc_result_d);
 }
 
@@ -1524,7 +1524,7 @@ void dppc_interpreter::ppc_stu() {
 #endif
     ppc_grab_regssa(ppc_cur_instruction);
     if (reg_a != 0) {
-        ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+        uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
         ppc_effective_address += ppc_result_a;
         mmu_write_vmem<T>(ppc_effective_address, ppc_result_d);
         ppc_state.gpr[reg_a] = ppc_effective_address;
@@ -1544,7 +1544,7 @@ void dppc_interpreter::ppc_stux() {
 #endif
     ppc_grab_regssab(ppc_cur_instruction);
     if (reg_a != 0) {
-        ppc_effective_address = ppc_result_a + ppc_result_b;
+        uint32_t ppc_effective_address = ppc_result_a + ppc_result_b;
         mmu_write_vmem<T>(ppc_effective_address, ppc_result_d);
         ppc_state.gpr[reg_a] = ppc_effective_address;
     } else {
@@ -1561,8 +1561,8 @@ void dppc_interpreter::ppc_sthbrx() {
     num_int_stores++;
 #endif
     ppc_grab_regssab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
-    ppc_result_d          = uint32_t(BYTESWAP_16(uint16_t(ppc_result_d)));
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    ppc_result_d = uint32_t(BYTESWAP_16(uint16_t(ppc_result_d)));
     mmu_write_vmem<uint16_t>(ppc_effective_address, ppc_result_d);
 }
 
@@ -1571,7 +1571,7 @@ void dppc_interpreter::ppc_stwcx() {
     num_int_stores++;
 #endif
     ppc_grab_regssab(ppc_cur_instruction);
-    ppc_effective_address = (reg_a == 0) ? ppc_result_b : (ppc_result_a + ppc_result_b);
+    uint32_t ppc_effective_address = (reg_a == 0) ? ppc_result_b : (ppc_result_a + ppc_result_b);
     ppc_state.cr &= 0x0FFFFFFFUL; // clear CR0
     ppc_state.cr |= (ppc_state.spr[SPR::XER] & XER::SO) >> 3; // copy XER[SO] to CR0[SO]
     if (ppc_state.reserve) {
@@ -1586,7 +1586,7 @@ void dppc_interpreter::ppc_stwbrx() {
     num_int_stores++;
 #endif
     ppc_grab_regssab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
     ppc_result_d          = BYTESWAP_32(ppc_result_d);
     mmu_write_vmem<uint32_t>(ppc_effective_address, ppc_result_d);
 }
@@ -1596,7 +1596,7 @@ void dppc_interpreter::ppc_stmw() {
     num_int_stores++;
 #endif
     ppc_grab_regssa_stmw(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += reg_a ? ppc_result_a : 0;
 
     /* what should we do if EA is unaligned? */
@@ -1616,7 +1616,7 @@ void dppc_interpreter::ppc_lz() {
     num_int_loads++;
 #endif
     ppc_grab_regsda(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += reg_a ? ppc_result_a : 0;
     uint32_t ppc_result_d = mmu_read_vmem<T>(ppc_effective_address);
     ppc_store_iresult_reg(reg_d, ppc_result_d);
@@ -1632,7 +1632,7 @@ void dppc_interpreter::ppc_lzu() {
     num_int_loads++;
 #endif
     ppc_grab_regsda(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     if ((reg_a != reg_d) && reg_a != 0) {
         ppc_effective_address += ppc_result_a;
         uint32_t ppc_result_d = mmu_read_vmem<T>(ppc_effective_address);
@@ -1654,7 +1654,7 @@ void dppc_interpreter::ppc_lzx() {
     num_int_loads++;
 #endif
     ppc_grab_regsdab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
     uint32_t ppc_result_d = mmu_read_vmem<T>(ppc_effective_address);
     ppc_store_iresult_reg(reg_d, ppc_result_d);
 }
@@ -1670,7 +1670,7 @@ void dppc_interpreter::ppc_lzux() {
 #endif
     ppc_grab_regsdab(ppc_cur_instruction);
     if ((reg_a != reg_d) && reg_a != 0) {
-        ppc_effective_address = ppc_result_a + ppc_result_b;
+        uint32_t ppc_effective_address = ppc_result_a + ppc_result_b;
         uint32_t ppc_result_d = mmu_read_vmem<T>(ppc_effective_address);
         ppc_result_a          = ppc_effective_address;
         ppc_store_iresult_reg(reg_d, ppc_result_d);
@@ -1689,7 +1689,7 @@ void dppc_interpreter::ppc_lha() {
     num_int_loads++;
 #endif
     ppc_grab_regsda(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += (reg_a ? ppc_result_a : 0);
     int16_t val = mmu_read_vmem<uint16_t>(ppc_effective_address);
     ppc_store_iresult_reg(reg_d, int32_t(val));
@@ -1701,7 +1701,7 @@ void dppc_interpreter::ppc_lhau() {
 #endif
     ppc_grab_regsda(ppc_cur_instruction);
     if ((reg_a != reg_d) && reg_a != 0) {
-        ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+        uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
         ppc_effective_address += ppc_result_a;
         int16_t val = mmu_read_vmem<uint16_t>(ppc_effective_address);
         ppc_store_iresult_reg(reg_d, int32_t(val));
@@ -1718,7 +1718,7 @@ void dppc_interpreter::ppc_lhaux() {
 #endif
     ppc_grab_regsdab(ppc_cur_instruction);
     if ((reg_a != reg_d) && reg_a != 0) {
-        ppc_effective_address = ppc_result_a + ppc_result_b;
+        uint32_t ppc_effective_address = ppc_result_a + ppc_result_b;
         int16_t val = mmu_read_vmem<uint16_t>(ppc_effective_address);
         ppc_store_iresult_reg(reg_d, int32_t(val));
         uint32_t ppc_result_a = ppc_effective_address;
@@ -1734,7 +1734,7 @@ void dppc_interpreter::ppc_lhax() {
     num_int_loads++;
 #endif
     ppc_grab_regsdab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
     int16_t val = mmu_read_vmem<uint16_t>(ppc_effective_address);
     ppc_store_iresult_reg(reg_d, int32_t(val));
 }
@@ -1744,7 +1744,7 @@ void dppc_interpreter::ppc_lhbrx() {
     num_int_loads++;
 #endif
     ppc_grab_regsdab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
     uint32_t ppc_result_d = uint32_t(BYTESWAP_16(mmu_read_vmem<uint16_t>(ppc_effective_address)));
     ppc_store_iresult_reg(reg_d, ppc_result_d);
 }
@@ -1754,7 +1754,7 @@ void dppc_interpreter::ppc_lwbrx() {
     num_int_loads++;
 #endif
     ppc_grab_regsdab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
     uint32_t ppc_result_d = BYTESWAP_32(mmu_read_vmem<uint32_t>(ppc_effective_address));
     ppc_store_iresult_reg(reg_d, ppc_result_d);
 }
@@ -1765,7 +1765,7 @@ void dppc_interpreter::ppc_lwarx() {
 #endif
     // Placeholder - Get the reservation of memory implemented!
     ppc_grab_regsdab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
     ppc_state.reserve     = true;
     uint32_t ppc_result_d = mmu_read_vmem<uint32_t>(ppc_effective_address);
     ppc_store_iresult_reg(reg_d, ppc_result_d);
@@ -1776,7 +1776,7 @@ void dppc_interpreter::ppc_lmw() {
     num_int_loads++;
 #endif
     ppc_grab_regsda(ppc_cur_instruction);
-    ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
+    uint32_t ppc_effective_address = int32_t(int16_t(ppc_cur_instruction));
     ppc_effective_address += (reg_a ? ppc_result_a : 0);
     // How many words to load in memory - using a do-while for this
     do {
@@ -1791,9 +1791,9 @@ void dppc_interpreter::ppc_lswi() {
     num_int_loads++;
 #endif
     ppc_grab_regsda(ppc_cur_instruction);
-    ppc_effective_address = reg_a ? ppc_result_a : 0;
-    uint32_t grab_inb     = (ppc_cur_instruction >> 11) & 0x1F;
-    grab_inb              = grab_inb ? grab_inb : 32;
+    uint32_t ppc_effective_address = reg_a ? ppc_result_a : 0;
+    uint32_t grab_inb              = (ppc_cur_instruction >> 11) & 0x1F;
+    grab_inb                       = grab_inb ? grab_inb : 32;
 
     while (grab_inb >= 4) {
         ppc_state.gpr[reg_d] = mmu_read_vmem<uint32_t>(ppc_effective_address);
@@ -1837,7 +1837,7 @@ void dppc_interpreter::ppc_lswx() {
     }
 */
 
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
     uint32_t grab_inb      = ppc_state.spr[SPR::XER] & 0x7F;
 
     for (;;) {
@@ -1871,7 +1871,7 @@ void dppc_interpreter::ppc_stswi() {
     num_int_stores++;
 #endif
     ppc_grab_regssash_stswi(ppc_cur_instruction);
-    ppc_effective_address = reg_a ? ppc_result_a : 0;
+    uint32_t ppc_effective_address = reg_a ? ppc_result_a : 0;
     uint32_t grab_inb = rot_sh ? rot_sh : 32;
 
     while (grab_inb >= 4) {
@@ -1906,8 +1906,8 @@ void dppc_interpreter::ppc_stswx() {
     num_int_stores++;
 #endif
     ppc_grab_regssab_stswx(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
-    uint32_t grab_inb     = ppc_state.spr[SPR::XER] & 127;
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t grab_inb = ppc_state.spr[SPR::XER] & 127;
 
     while (grab_inb >= 4) {
         mmu_write_vmem<uint32_t>(ppc_effective_address, ppc_state.gpr[reg_s]);
@@ -1945,7 +1945,7 @@ void dppc_interpreter::ppc_eciwx() {
     }
 
     ppc_grab_regsdab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
 
     if (ppc_effective_address & 0x3) {
         ppc_alignment_exception(ppc_effective_address);
@@ -1965,7 +1965,7 @@ void dppc_interpreter::ppc_ecowx() {
     }
 
     ppc_grab_regssab(ppc_cur_instruction);
-    ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
+    uint32_t ppc_effective_address = ppc_result_b + (reg_a ? ppc_result_a : 0);
 
     if (ppc_effective_address & 0x3) {
         ppc_alignment_exception(ppc_effective_address);


### PR DESCRIPTION
There's no reason for it to be a global, we always set it and use it in instruction implementations, and we never read it directly.

Perhaps the compiler could optimize this away, but it's better to be simpler (and also be easier to read).