### PR TITLE
Fix ATA HD initialization on Beige G3 when booting 9.2

### DIFF
--- a/devices/common/ata/atahd.cpp
+++ b/devices/common/ata/atahd.cpp
@@ -105,13 +105,13 @@ int AtaHardDisk::perform_command() {
             uint64_t offset    = this->get_lba() * ATA_HD_SEC_SIZE;
             uint32_t ints_size = ATA_HD_SEC_SIZE;
             if (this->r_command == READ_MULTIPLE) {
-                if (this->multiple_sector_count == 0) {
+                if (this->sec_per_block == 0) {
                     LOG_F(ERROR, "%s: READ MULTIPLE with SET MULTIPLE==0", this->name.c_str());
                     this->r_status |= ERR;
                     this->r_status &= ~BSY;
                     break;
                 }
-                ints_size *= this->multiple_sector_count;
+                ints_size *= this->sec_per_block;
             }
             hdd_img.read(buffer, offset, xfer_size);
             this->data_ptr = (uint16_t *)this->buffer;
@@ -130,13 +130,13 @@ int AtaHardDisk::perform_command() {
             uint32_t xfer_size = sec_count * ATA_HD_SEC_SIZE;
             uint32_t ints_size = ATA_HD_SEC_SIZE;
             if (this->r_command == WRITE_MULTIPLE) {
-                if (this->multiple_sector_count == 0) {
+                if (this->sec_per_block == 0) {
                     LOG_F(ERROR, "%s: WRITE MULTIPLE with SET MULTIPLE==0", this->name.c_str());
                     this->r_status |= ERR;
                     this->r_status &= ~BSY;
                     break;
                 }
-                ints_size *= this->multiple_sector_count;
+                ints_size *= this->sec_per_block;
             }
             this->prepare_xfer(xfer_size, ints_size);
             this->post_xfer_action = [this]() {

--- a/devices/common/ata/atahd.h
+++ b/devices/common/ata/atahd.h
@@ -69,9 +69,6 @@ private:
     uint8_t     heads;
     uint8_t     sectors;
 
-    //number of sectors for r/w multiple
-    uint8_t multiple_sector_count = 0;
-
     uint8_t     sec_per_block    = 8; // sectors per block for READ_MULTIPLE/WRITE_MULTIPLE
     bool        multiple_enabled = true; // READ_MULTIPLE/WRITE_MULTIPLE enabled
 


### PR DESCRIPTION
1f2256ec81a and 7ee8b9b2f were referencing a `multiple_sector_count` field, but it was never set. This was resulting in an error being returned (`READ MULTIPLE with SET MULTIPLE==0`). We actually should use `sec_per_block`, which bd16b7c69ee27 introduced.