### PR TITLE
AppleJack (Pippin) controller support

### DIFF
--- a/core/hostevents.h
+++ b/core/hostevents.h
@@ -40,6 +40,8 @@ enum : uint32_t {
     MOUSE_EVENT_BUTTON = 1 << 1,
     KEYBOARD_EVENT_DOWN = 1 << 0,
     KEYBOARD_EVENT_UP = 1 << 1,
+    GAMEPAD_EVENT_DOWN = 1 << 0,
+    GAMEPAD_EVENT_UP = 1 << 1,
 };
 
 class MouseEvent {
@@ -63,6 +65,36 @@ public:
     uint32_t flags;
     uint32_t key;
     uint16_t keys_state;
+};
+
+/* AppleJack bits 3-7 are supported but unused */
+enum GamepadButton : uint8_t {
+    Red =          14,
+    Green =        15,
+    Yellow =       9,
+    Blue =         8,
+
+    FrontLeft =    0,
+    FrontMiddle =  1,
+    FrontRight =   2,
+
+    LeftTrigger =  17,
+    RightTrigger = 16,
+
+    Up =           10,
+    Down =         13,
+    Left =         11,
+    Right =        12,
+};
+
+class GamepadEvent {
+public:
+    GamepadEvent() = default;
+    ~GamepadEvent() = default;
+
+    uint32_t gamepad_id;
+    uint32_t flags;
+    uint8_t button;
 };
 
 class EventManager {
@@ -92,6 +124,11 @@ public:
     }
 
     template <typename T>
+    void add_gamepad_handler(T* inst, void (T::*func)(const GamepadEvent&)) {
+        _gamepad_signal.connect_method(inst, func);
+    }
+
+    template <typename T>
     void add_post_handler(T *inst, void (T::*func)()) {
         _post_signal.connect_method(inst, func);
     }
@@ -110,6 +147,7 @@ private:
     CoreSignal<const WindowEvent&>     _window_signal;
     CoreSignal<const MouseEvent&>      _mouse_signal;
     CoreSignal<const KeyboardEvent&>   _keyboard_signal;
+    CoreSignal<const GamepadEvent&>    _gamepad_signal;
     CoreSignal<>                       _post_signal;
 
     uint64_t    events_captured = 0;

--- a/core/hostevents_sdl.cpp
+++ b/core/hostevents_sdl.cpp
@@ -130,6 +130,52 @@ void EventManager::poll_events()
             }
             break;
 
+        case SDL_CONTROLLERBUTTONDOWN: {
+                GamepadEvent ge;
+                switch (event.cbutton.button) {
+                    case SDL_CONTROLLER_BUTTON_BACK:          ge.button = GamepadButton::FrontLeft;    break;
+                    case SDL_CONTROLLER_BUTTON_GUIDE:         ge.button = GamepadButton::FrontMiddle;  break;
+                    case SDL_CONTROLLER_BUTTON_START:         ge.button = GamepadButton::FrontRight;   break;
+                    case SDL_CONTROLLER_BUTTON_Y:             ge.button = GamepadButton::Blue;         break;
+                    case SDL_CONTROLLER_BUTTON_X:             ge.button = GamepadButton::Yellow;       break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_UP:       ge.button = GamepadButton::Up;           break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:     ge.button = GamepadButton::Left;         break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:    ge.button = GamepadButton::Right;        break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_DOWN:     ge.button = GamepadButton::Down;         break;
+                    case SDL_CONTROLLER_BUTTON_A:             ge.button = GamepadButton::Red;          break;
+                    case SDL_CONTROLLER_BUTTON_B:             ge.button = GamepadButton::Green;        break;
+                    case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: ge.button = GamepadButton::RightTrigger; break;
+                    case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:  ge.button = GamepadButton::LeftTrigger;  break;
+                }
+                ge.gamepad_id = event.cbutton.which;
+                ge.flags = GAMEPAD_EVENT_DOWN;
+                this->_gamepad_signal.emit(ge);
+            }
+            break;
+
+        case SDL_CONTROLLERBUTTONUP: {
+                GamepadEvent ge;
+                switch (event.cbutton.button) {
+                    case SDL_CONTROLLER_BUTTON_BACK:          ge.button = GamepadButton::FrontLeft;    break;
+                    case SDL_CONTROLLER_BUTTON_GUIDE:         ge.button = GamepadButton::FrontMiddle;  break;
+                    case SDL_CONTROLLER_BUTTON_START:         ge.button = GamepadButton::FrontRight;   break;
+                    case SDL_CONTROLLER_BUTTON_Y:             ge.button = GamepadButton::Blue;         break;
+                    case SDL_CONTROLLER_BUTTON_X:             ge.button = GamepadButton::Yellow;       break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_UP:       ge.button = GamepadButton::Up;           break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:     ge.button = GamepadButton::Left;         break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:    ge.button = GamepadButton::Right;        break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_DOWN:     ge.button = GamepadButton::Down;         break;
+                    case SDL_CONTROLLER_BUTTON_A:             ge.button = GamepadButton::Red;          break;
+                    case SDL_CONTROLLER_BUTTON_B:             ge.button = GamepadButton::Green;        break;
+                    case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: ge.button = GamepadButton::RightTrigger; break;
+                    case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:  ge.button = GamepadButton::LeftTrigger;  break;
+                }
+                ge.gamepad_id = event.cbutton.which;
+                ge.flags = GAMEPAD_EVENT_UP;
+                this->_gamepad_signal.emit(ge);
+            }
+            break;
+
         default:
             unhandled_events++;
         }

--- a/devices/common/adb/adbapplejack.cpp
+++ b/devices/common/adb/adbapplejack.cpp
@@ -1,0 +1,100 @@
+/*
+DingusPPC - The Experimental PowerPC Macintosh emulator
+Copyright (C) 2018-24 divingkatae and maximum
+                      (theweirdo)     spatium
+
+(Contact divingkatae#1017 or powermax#2286 on Discord for more info)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/** @file Apple Desktop Bus AppleJack controller emulation. */
+
+#include <devices/common/adb/adbapplejack.h>
+#include <devices/common/adb/adbbus.h>
+#include <devices/deviceregistry.h>
+#include <core/hostevents.h>
+#include <loguru.hpp>
+
+AdbAppleJack::AdbAppleJack(std::string name) : AdbMouse(name, AdbMouse::TRACKBALL, 2, 7, 300) {
+    EventManager::get_instance()->add_gamepad_handler(this, &AdbAppleJack::event_handler);
+}
+
+void AdbAppleJack::event_handler(const GamepadEvent& event) {
+    uint32_t button_bit = 1 << event.button;
+
+    if (event.flags & GAMEPAD_EVENT_DOWN)
+        this->buttons_state |= button_bit;
+    else if (event.flags & GAMEPAD_EVENT_UP)
+        this->buttons_state &= ~button_bit;
+
+    if (button_bit & ((1 << GamepadButton::LeftTrigger) | (1 << GamepadButton::RightTrigger)))
+        this->triggers_changed = true;
+    else
+        this->buttons_changed = true;
+}
+
+void AdbAppleJack::reset() {
+    this->AdbMouse::reset();
+    this->buttons_state = 0;
+    this->triggers_changed = false;
+    this->buttons_changed = false;
+    LOG_F(INFO, "%s: reset; in mouse emulation mode", this->name.c_str());
+}
+
+bool AdbAppleJack::get_register_0() {
+    bool changed = this->triggers_changed || this->buttons_changed;
+
+    uint8_t mouse_buttons = this->AdbMouse::get_buttons_state();
+    // AppleJack triggers always affect the mouse button bits.
+    mouse_buttons |= (this->buttons_state >> (GamepadButton::LeftTrigger  - 0)) & 1;
+    mouse_buttons |= (this->buttons_state >> (GamepadButton::RightTrigger - 1)) & 2;
+    changed |= this->AdbMouse::get_register_0(mouse_buttons, changed);
+    this->triggers_changed = false;
+
+    if (this->dev_handler_id == APPLEJACK_HANDLER_ID && this->buttons_changed) {
+        uint8_t* out_buf = this->host_obj->get_output_buf();
+
+        out_buf[2] = ~this->buttons_state >> 8;
+        out_buf[3] = ~this->buttons_state & 0xFF;
+
+        this->host_obj->set_output_count(4);
+        this->buttons_changed = false;
+    }
+
+    return changed;
+}
+
+void AdbAppleJack::set_register_3() {
+    if (this->host_obj->get_input_count() < 2) // ensure we got enough data
+        return;
+
+    const uint8_t* in_data = this->host_obj->get_input_buf();
+
+    switch (in_data[1]) {
+    case APPLEJACK_HANDLER_ID: // switch over to AppleJack protocol
+        this->dev_handler_id = in_data[1];
+        LOG_F(INFO, "%s: switched to AppleJack mode", this->name.c_str());
+        break;
+    default:
+        this->AdbMouse::set_register_3();
+        break;
+    }
+}
+
+static const DeviceDescription AdbAppleJack_Descriptor = {
+    AdbAppleJack::create, {}, {}
+};
+
+REGISTER_DEVICE(AdbAppleJack, AdbAppleJack_Descriptor);

--- a/devices/common/adb/adbapplejack.h
+++ b/devices/common/adb/adbapplejack.h
@@ -1,0 +1,60 @@
+/*
+DingusPPC - The Experimental PowerPC Macintosh emulator
+Copyright (C) 2018-24 divingkatae and maximum
+                      (theweirdo)     spatium
+
+(Contact divingkatae#1017 or powermax#2286 on Discord for more info)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/** @file Apple Desktop Bus AppleJack controller definitions. */
+
+#ifndef ADB_APPLEJACK_H
+#define ADB_APPLEJACK_H
+
+#include <devices/common/adb/adbmouse.h>
+#include <devices/common/hwcomponent.h>
+
+#include <memory>
+#include <string>
+
+enum : uint8_t {
+    APPLEJACK_HANDLER_ID = 0x46,
+};
+
+class GamepadEvent;
+
+class AdbAppleJack : public AdbMouse {
+public:
+    AdbAppleJack(std::string name);
+    ~AdbAppleJack() = default;
+
+    static std::unique_ptr<HWComponent> create() {
+        return std::unique_ptr<AdbAppleJack>(new AdbAppleJack("ADB-APPLEJACK"));
+    }
+
+    void reset() override;
+    void event_handler(const GamepadEvent& event);
+
+    bool get_register_0() override;
+    void set_register_3() override;
+
+private:
+    uint32_t buttons_state = 0;
+    bool triggers_changed = false;
+    bool buttons_changed = false;
+};
+
+#endif // ADB_APPLEJACK_H

--- a/devices/common/adb/adbbus.h
+++ b/devices/common/adb/adbbus.h
@@ -51,6 +51,8 @@ public:
         return std::unique_ptr<AdbBus>(new AdbBus("ADB-BUS"));
     }
 
+    int device_postinit() override;
+
     void register_device(AdbDevice* dev_obj);
     uint8_t process_command(const uint8_t* in_data, int data_size);
     uint8_t get_output_count() { return this->output_count; };

--- a/devices/common/adb/adbmouse.h
+++ b/devices/common/adb/adbmouse.h
@@ -35,19 +35,31 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class MouseEvent;
 
 class AdbMouse : public AdbDevice {
-
+public:
 enum DeviceClass {
     TABLET      = 0,
     MOUSE       = 1,
     TRACKBALL   = 2,
 };
 
-public:
-    AdbMouse(std::string name);
+    AdbMouse(
+        std::string name, uint8_t device_class, int num_buttons, int num_bits, uint16_t resolution);
     ~AdbMouse() = default;
 
     static std::unique_ptr<HWComponent> create() {
-        return std::unique_ptr<AdbMouse>(new AdbMouse("ADB-MOUSE"));
+#ifdef ABSOLUTE
+        uint8_t  device_class = TABLET;
+        int      num_buttons = 3;
+        int      num_bits = 16;
+        uint16_t resolution = 72;
+#else
+        uint8_t  device_class = MOUSE;
+        int      num_buttons = 3;
+        int      num_bits = 10;
+        uint16_t resolution = 300;
+#endif
+        return std::unique_ptr<AdbMouse>(
+            new AdbMouse("ADB-MOUSE", device_class, num_buttons, num_bits, resolution));
     }
 
     void reset() override;
@@ -57,6 +69,10 @@ public:
     bool get_register_1() override;
     void set_register_3() override;
 
+protected:
+    bool get_register_0(uint8_t buttons_state, bool force);
+    uint8_t get_buttons_state() const;
+
 private:
     int32_t  x_rel = 0;
     int32_t  y_rel = 0;
@@ -64,17 +80,10 @@ private:
     int32_t  y_abs = 0;
     uint8_t  buttons_state = 0;
     bool     changed = false;
-#ifdef ABSOLUTE
-    uint8_t  device_class = TABLET;
-    int      num_buttons = 3;
-    int      num_bits = 16;
-    uint16_t resolution = 72;
-#else
-    uint8_t  device_class = MOUSE;
-    int      num_buttons = 3;
-    int      num_bits = 10;
-    uint16_t resolution = 300;
-#endif
+    uint8_t  device_class;
+    int      num_buttons;
+    int      num_bits;
+    uint16_t resolution;
 };
 
 #endif // ADB_MOUSE_H

--- a/devices/common/viacuda.cpp
+++ b/devices/common/viacuda.cpp
@@ -836,7 +836,7 @@ void ViaCuda::i2c_comb_transaction(
 }
 
 static const vector<string> Cuda_Subdevices = {
-    "AdbBus", "AdbMouse", "AdbKeyboard"
+    "AdbBus"
 };
 
 static const DeviceDescription ViaCuda_Descriptor = {

--- a/machines/machinefactory.cpp
+++ b/machines/machinefactory.cpp
@@ -98,6 +98,7 @@ static const map<string, string> PropHelp = {
     {"serial_backend",  "specifies the backend for the serial port"},
     {"emmo",            "enables/disables factory HW tests during startup"},
     {"cpu",             "specifies CPU"},
+    {"adb_devices",     "specifies which ADB device(s) to attach"},
 };
 
 bool MachineFactory::add(const string& machine_id, MachineDescription desc)

--- a/machines/machinepippin.cpp
+++ b/machines/machinepippin.cpp
@@ -74,6 +74,8 @@ static const PropMap Pippin_Settings = {
         new IntProperty(0, vector<uint32_t>({0, 1, 4, 8, 16}))},
     {"emmo",
         new BinProperty(0)},
+    {"adb_devices",
+        new StrProperty("AppleJack,Keyboard")},
 };
 
 static vector<string> Pippin_Devices = {

--- a/main_sdl.cpp
+++ b/main_sdl.cpp
@@ -30,9 +30,17 @@ extern "C" void remap_appkit_menu_shortcuts();
 #endif
 
 bool init() {
-    if (SDL_Init(SDL_INIT_VIDEO)) {
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER)) {
         LOG_F(ERROR, "SDL_Init error: %s", SDL_GetError());
         return false;
+    }
+
+    int num_joysticks = SDL_NumJoysticks();
+    for (int i = 0; i < num_joysticks; ++i) {
+        if (SDL_IsGameController(i)) {
+            SDL_GameControllerOpen(i); /* only support one controller for now */
+            break;
+        }
     }
 
 #ifdef __APPLE__

--- a/zdocs/users/manual.md
+++ b/zdocs/users/manual.md
@@ -5,7 +5,7 @@
 * Interpreter (with 601, FPU, and MMU support)
 * IDE and SCSI 
 * Floppy disk image reading (Raw, Disk Copy 4.2, WOZ v1 and v2)
-* ADB mouse and keyboard emulation
+* ADB mouse, keyboard, and AppleJack (Pippin) controller emulation
 * Some audio support
 * Basic video output support (i.e. ATI Rage, Control, Platinum)
 
@@ -110,6 +110,12 @@ Access the factory tests
 ```
 --serial_backend=stdio
 --serial_backend=socket
+```
+
+Set the ADB devices to attach, comma-separated
+
+```
+--adb_devices TEXT
 ```
 
 Change where the output of OpenFirmware is directed to, either to the command line (with stdio) or a Unix socket (unavailable in Windows builds). OpenFirmware 1.x outputs here by default.


### PR DESCRIPTION
Add support for the Pippin controller, now that rudimentary support for Pippin is present. Use SDL's GameController API for a consistent button mapping across popular modern gamepads. Refactor AdbMouse to support passing mouse specifications at construction time in addition to hardcoding via a preprocessor macro. Likewise, add new "adb_devices" property to allow for users to specify at launch which ADB devices should be emulated, rather than hardcoding mouse and keyboard for all machine types.