### PR TITLE
Enable HiDPI mode for SDL and ensure that we use nearest-neighbor scaling

### DIFF
--- a/core/hostevents.h
+++ b/core/hostevents.h
@@ -35,6 +35,12 @@ public:
     uint32_t    window_id;
 };
 
+enum : uint16_t {
+    // Standard SDL window event types are uint8_t's, we add our own custom
+    // events after that.
+    WINDOW_SCALE_QUALITY_TOGGLE = 1 << 8,
+};
+
 enum : uint32_t {
     MOUSE_EVENT_MOTION = 1 << 0,
     MOUSE_EVENT_BUTTON = 1 << 1,

--- a/core/hostevents_sdl.cpp
+++ b/core/hostevents_sdl.cpp
@@ -54,11 +54,21 @@ void EventManager::poll_events()
 
         case SDL_KEYDOWN:
         case SDL_KEYUP: {
-                // Internal shortcuts to trigger mouse grab, intentionally not
-                // sent to the host.
+                // Internal shortcuts, intentionally not sent to the host.
+                // Control-G: mouse grab
                 if (event.key.keysym.sym == SDLK_g && SDL_GetModState() & KMOD_LCTRL) {
                     if (event.type == SDL_KEYUP) {
                         toggle_mouse_grab(event.key);
+                    }
+                    return;
+                }
+                // Control-S: scale quality
+                if (event.key.keysym.sym == SDLK_s && SDL_GetModState() & KMOD_LCTRL) {
+                    if (event.type == SDL_KEYUP) {
+                        WindowEvent we;
+                        we.sub_type  = WINDOW_SCALE_QUALITY_TOGGLE;
+                        we.window_id = event.window.windowID;
+                        this->_window_signal.emit(we);
                     }
                     return;
                 }


### PR DESCRIPTION
Avoids blurriness on macOS hosts with Retina displays.

| Before | After |
|--------|--------|
| <img width="1136" alt="image" src="https://github.com/user-attachments/assets/99631a45-44ec-42dd-9ca4-c71032b04422"> | <img width="1136" alt="image" src="https://github.com/user-attachments/assets/066054fa-f862-4ec0-8667-f96175d7d47f"> | 