### PR TITLE
Add a deterministic execution mode

### DIFF
--- a/core/coresignal.h
+++ b/core/coresignal.h
@@ -53,6 +53,9 @@ public:
 
     // Calls all connected slots.
     void emit(Args... args) {
+        if (!_is_enabled) {
+            return;
+        }
         for (auto const& it : _slots) {
             it.second(args...);
         }
@@ -66,9 +69,22 @@ public:
         _slots.clear();
     }
 
+    void disable() {
+        _is_enabled = false;
+    }
+
+    void enable() {
+        _is_enabled = true;
+    }
+
+    bool is_enabled() {
+        return _is_enabled;
+    }
+
 private:
     mutable std::map<int, std::function<void(Args...)>> _slots;
     mutable unsigned int _current_id { 0 };
+    mutable bool _is_enabled { true };
 };
 
 #endif // CORE_SIGNAL_H

--- a/core/hostevents.h
+++ b/core/hostevents.h
@@ -146,6 +146,11 @@ public:
         _post_signal.disconnect_all();
     }
 
+    void disable_input_handlers() {
+        _mouse_signal.disable();
+        _keyboard_signal.disable();
+    }
+
 private:
     static EventManager* event_manager;
     EventManager() {}; // private constructor to implement a singleton

--- a/core/timermanager.h
+++ b/core/timermanager.h
@@ -31,8 +31,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 #include <mutex>
 
-using namespace std;
-
 #define NS_PER_SEC      1000000000
 #define USEC_PER_SEC    1000000
 #define NS_PER_USEC     1000
@@ -42,7 +40,7 @@ using namespace std;
 #define USECS_TO_NSECS(us) (us) * NS_PER_USEC
 #define MSECS_TO_NSECS(ms) (ms) * NS_PER_MSEC
 
-typedef function<void()> timer_cb;
+typedef std::function<void()> timer_cb;
 
 /** Extend std::priority_queue as suggested here:
     https://stackoverflow.com/a/36711682
@@ -101,7 +99,7 @@ typedef struct TimerInfo {
 // Custom comparator for sorting our timer queue in ascending order
 class MyGtComparator {
 public:
-    bool operator()(const shared_ptr<TimerInfo>& l, const shared_ptr<TimerInfo>& r) {
+    bool operator()(const std::shared_ptr<TimerInfo>& l, const std::shared_ptr<TimerInfo>& r) {
         return l.get()->timeout_ns > r.get()->timeout_ns;
     }
 };
@@ -116,7 +114,7 @@ public:
     };
 
     // callback for retrieving current time
-    void set_time_now_cb(const function<uint64_t()> &cb) {
+    void set_time_now_cb(const std::function<uint64_t()> &cb) {
         this->get_time_now = cb;
     };
 
@@ -142,10 +140,10 @@ private:
     TimerManager(){}; // private constructor to implement a singleton
 
     // timer queue
-    my_priority_queue<shared_ptr<TimerInfo>, vector<shared_ptr<TimerInfo>>, MyGtComparator> timer_queue;
+    my_priority_queue<std::shared_ptr<TimerInfo>, std::vector<std::shared_ptr<TimerInfo>>, MyGtComparator> timer_queue;
 
-    function<uint64_t()>   get_time_now;
-    function<void()>       notify_timer_changes;
+    std::function<uint64_t()>   get_time_now;
+    std::function<void()>       notify_timer_changes;
 
     std::atomic<uint32_t> id{0};
     bool        cb_active = false; // true if a timer callback is executing // FIXME: Do we need this? It gets written in main thread and read in audio thread.

--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -328,6 +328,9 @@ extern bool is_601;        // For PowerPC 601 Emulation
 extern bool is_altivec;    // For Altivec Emulation
 extern bool is_64bit;      // For PowerPC G5 Emulation
 
+// Make execution deterministic (ignore external input, used a fixed date, etc.)
+extern bool is_deterministic;
+
 // Important Addressing Integers
 extern uint32_t ppc_cur_instruction;
 extern uint32_t ppc_next_instruction_address;

--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -57,6 +57,8 @@ MemCtrlBase* mem_ctrl_instance = 0;
 
 bool is_601 = false;
 
+bool is_deterministic = false;
+
 bool power_on = false;
 Po_Cause power_off_reason = po_enter_debugger;
 

--- a/devices/common/nvram.cpp
+++ b/devices/common/nvram.cpp
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include <cpu/ppc/ppcemu.h>
 #include <devices/common/hwcomponent.h>
 #include <devices/common/nvram.h>
 #include <devices/deviceregistry.h>
@@ -81,6 +82,10 @@ void NVram::init() {
 }
 
 void NVram::save() {
+    if (is_deterministic) {
+        LOG_F(INFO, "Skipping NVRAM write to \"%s\" in deterministic mode", this->file_name.c_str());
+        return;
+    }
     ofstream f(this->file_name, ios::out | ios::binary);
 
     /* write file identification */

--- a/devices/common/viacuda.cpp
+++ b/devices/common/viacuda.cpp
@@ -751,7 +751,22 @@ void ViaCuda::pseudo_command() {
 }
 
 uint32_t ViaCuda::calc_real_time() {
-    auto end = std::chrono::system_clock::now();
+    std::chrono::time_point<std::chrono::system_clock> end;
+    if (is_deterministic) {
+        // March 24, 2001 was the public release date of Mac OS X.
+        std::tm tm = {
+            .tm_sec  = 0,
+            .tm_min  = 0,
+            .tm_hour = 12,
+            .tm_mday = 24,
+            .tm_mon  = 3 - 1,
+            .tm_year = 2001 - 1900,
+            .tm_isdst = 0
+        };
+        end = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+    } else {
+        end = std::chrono::system_clock::now();
+    }
     auto elapsed_systemclock = end - this->mac_epoch;
     auto elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds>(elapsed_systemclock);
     return uint32_t(elapsed_seconds.count());

--- a/devices/sound/awacs.cpp
+++ b/devices/sound/awacs.cpp
@@ -69,8 +69,7 @@ void AwacsBase::dma_out_start() {
     }
 
     if (!this->out_stream_ready) {
-        if ((err = this->snd_server->open_out_stream(this->cur_sample_rate,
-            (void *)this->dma_out_ch))) {
+        if ((err = this->snd_server->open_out_stream(this->cur_sample_rate, this->dma_out_ch))) {
             LOG_F(ERROR, "%s: unable to open sound output stream: %d",
                   this->name.c_str(), err);
             return;

--- a/devices/sound/soundserver.h
+++ b/devices/sound/soundserver.h
@@ -38,6 +38,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <memory>
 
+class DmaOutChannel;
+
 class SoundServer : public HWComponent {
 public:
     SoundServer();
@@ -45,7 +47,7 @@ public:
 
     int start();
     void shutdown();
-    int open_out_stream(uint32_t sample_rate, void *user_data);
+    int open_out_stream(uint32_t sample_rate, DmaOutChannel *dma_ch);
     int start_out_stream();
     void close_out_stream();
 


### PR DESCRIPTION
Adds support for a `--deterministic` command-line option that makes repeated runs the same:
- Keyboard and mouse input is ignored
- The sound server does a periodic pull from the DMA channel (so that it gets drained), but only does so via a periodic timer (instead of being driven by a cubeb callback, which could arrive at different times)
- Disk image writes are disabled (reads of a modified area still work via an in-memory copy)
- NVRAM writes are disabled
- The current time that `ViaCuda` initializes the guest OS is always the same.

This makes execution exactly the same each time, which should make debugging of more subtle issues easier.

To validate that the deterministic mode is working, I've added a periodic log of the current "time" (measured in cycle count), PC and opcode. When comparing two runs with `--log-no-uptime`, the generated log files are identical.