### PR TITLE
Add support for specifying properties of dynamically-registered devices via the command line

### DIFF
--- a/devices/common/pci/pcihost.cpp
+++ b/devices/common/pci/pcihost.cpp
@@ -119,9 +119,8 @@ PCIBase *PCIHost::attach_pci_device(const std::string& dev_name, int slot_id, co
     }
 
     // attempt to create device object
+    MachineFactory::register_device_settings(dev_name);
     auto desc = DeviceRegistry::get_descriptor(dev_name);
-    map<string, string> settings;
-    MachineFactory::get_device_settings(desc, settings);
     auto dev_obj = desc.m_create_func();
 
     if (!dev_obj->supports_type(HWCompType::PCI_DEV)) {

--- a/machines/machinefactory.h
+++ b/machines/machinefactory.h
@@ -29,7 +29,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <machines/machineproperties.h>
 
+#include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -45,6 +47,8 @@ struct MachineDescription {
     function<int(string&)>  init_func;
 };
 
+typedef std::function<std::optional<std::string>(const std::string&)> GetSettingValueFunc;
+
 class MachineFactory
 {
 public:
@@ -57,18 +61,20 @@ public:
     static int create(string& mach_id);
     static int create_machine_for_id(string& id, string& rom_filepath);
 
-    static void get_device_settings(DeviceDescription& dev, map<string, string> &settings);
-    static int get_machine_settings(const string& id, map<string, string> &settings);
-    static void set_machine_settings(map<string, string> &settings);
+    static void register_device_settings(const std::string &name);
+    static int  register_machine_settings(const std::string& id);
 
     static void list_machines();
     static void list_properties();
 
+    static GetSettingValueFunc get_setting_value;
+
 private:
     static void create_device(string& dev_name, DeviceDescription& dev);
-    static void print_settings(PropMap& p);
+    static void print_settings(const PropMap& p);
     static void list_device_settings(DeviceDescription& dev);
     static int  load_boot_rom(string& rom_filepath);
+    static void register_settings(const PropMap& p);
 
     static map<string, MachineDescription> & get_registry() {
         static map<string, MachineDescription> machine_registry;


### PR DESCRIPTION
The previous approach of traversing the machine and its device tree at startup to register CLI11 options was not working for dynamically registered devices like PCI cards. This meant that options like `gfxmem_size` or `mon_id` from the video cards could not be set.

Switch to instead registering in `MachineFactory` a hook function that provides CLI flag values. We can call it when registering any property, whether at startup or dynamically.