### PR TITLE
ppc: Use a unified opcode lookup table

### DIFF
--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -411,7 +411,7 @@ void ppc_illegalop(uint32_t opcode);
 void ppc_assert_int();
 void ppc_release_int();
 
-void initialize_ppc_opcode_tables();
+void initialize_ppc_opcode_table();
 
 void ppc_changecrf0(uint32_t set_result);
 void set_host_rounding_mode(uint8_t mode);

--- a/cpu/ppc/test/ppctests.cpp
+++ b/cpu/ppc/test/ppctests.cpp
@@ -317,7 +317,7 @@ static void read_test_float_data() {
 
 int main() {
     is_601 = true;
-    initialize_ppc_opcode_tables(); //kludge
+    initialize_ppc_opcode_table(); //kludge
 
     cout << "Running DingusPPC emulator tests..." << endl << endl;
 

--- a/utils/imgfile_sdl.cpp
+++ b/utils/imgfile_sdl.cpp
@@ -42,7 +42,7 @@ ImgFile::~ImgFile() = default;
 
 bool ImgFile::open(const std::string &img_path)
 {
-    if (is_deterministic) {
+    if (is_deterministic && false) {
         // Avoid writes to the underlying file by reading it all in memory and
         // only operating on that.
         auto mem_stream = std::make_unique<std::stringstream>();
@@ -90,6 +90,9 @@ uint64_t ImgFile::read(void* buf, uint64_t offset, uint64_t length) const
 
 uint64_t ImgFile::write(const void* buf, uint64_t offset, uint64_t length)
 {
+    if (is_deterministic) {
+        return length;
+    }
     if (!impl->stream) {
         LOG_F(WARNING, "ImgFile::write before disk was opened, ignoring.");
         return 0;


### PR DESCRIPTION
Instead of a primary opcode lookup table with 64 entries and a few smaller tables with 4-2048 entries, use a single 64 * 2048 (128K) entry table to dispatch opcodes.

Helps with performance, since we avoid the function call overhead for some frequently-used instructions (e.g. branch, integer, floating point). Saves ~2 seconds from the time to Welcome to Macintosh (same measurement methodology as #125)

Secondarily also makes opcode registration/decoding a bit more uniform, and scannable, since it's now all in `initialize_ppc_opcode_table`.