### PR TITLE
Remove `using namespace std` from remaining header files

### DIFF
--- a/devices/common/adb/adbbus.cpp
+++ b/devices/common/adb/adbbus.cpp
@@ -43,7 +43,7 @@ int AdbBus::device_postinit() {
     std::istringstream adb_device_stream(adb_device_list);
 
     while (getline(adb_device_stream, adb_device, ',')) {
-        string dev_name = "Adb" + adb_device;
+        std::string dev_name = "Adb" + adb_device;
 
         if (dev_name == this->name)
             continue; // don't register a second ADB bus

--- a/devices/common/pci/bandit.cpp
+++ b/devices/common/pci/bandit.cpp
@@ -259,7 +259,7 @@ Bandit::Bandit(int bridge_num, std::string name, int dev_id, int rev)
     mem_ctrl->add_mmio_region(base_addr, 0x01000000, this);
 
     // connnect Bandit PCI device
-    this->my_pci_device = unique_ptr<BanditPciDevice>(
+    this->my_pci_device = std::unique_ptr<BanditPciDevice>(
         new BanditPciDevice(bridge_num, name, dev_id, rev)
     );
     this->pci_register_device(DEV_FUN(BANDIT_DEV,0), this->my_pci_device.get());

--- a/devices/deviceregistry.cpp
+++ b/devices/deviceregistry.cpp
@@ -36,7 +36,7 @@ bool DeviceRegistry::add(const std::string name, DeviceDescription desc)
     return true;
 }
 
-bool DeviceRegistry::device_registered(const string dev_name)
+bool DeviceRegistry::device_registered(const std::string dev_name)
 {
     if (get_registry().find(dev_name) != get_registry().end()) {
         return true;
@@ -45,7 +45,7 @@ bool DeviceRegistry::device_registered(const string dev_name)
     return false;
 }
 
-unique_ptr<HWComponent> DeviceRegistry::create(const std::string& name)
+std::unique_ptr<HWComponent> DeviceRegistry::create(const std::string& name)
 {
     auto it = get_registry().find(name);
     if (it != get_registry().end()) {

--- a/devices/deviceregistry.h
+++ b/devices/deviceregistry.h
@@ -34,12 +34,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class HWComponent;
 
-typedef std::function<unique_ptr<HWComponent> ()> CreateFunc;
+typedef std::function<std::unique_ptr<HWComponent> ()> CreateFunc;
 
 struct DeviceDescription {
-    CreateFunc      m_create_func;
-    vector<string>  subdev_list;
-    PropMap         properties;
+    CreateFunc                m_create_func;
+    std::vector<std::string>  subdev_list;
+    PropMap                   properties;
 };
 
 class DeviceRegistry
@@ -47,17 +47,17 @@ class DeviceRegistry
 public:
     DeviceRegistry() = delete;
 
-    static bool add(const string name, DeviceDescription desc);
+    static bool add(const std::string name, DeviceDescription desc);
 
-    static bool device_registered(const string dev_name);
+    static bool device_registered(const std::string dev_name);
 
-    static unique_ptr<HWComponent> create(const string& name);
+    static std::unique_ptr<HWComponent> create(const std::string& name);
 
     static DeviceDescription& get_descriptor(const std::string& name);
 
 private:
-    static map<string, DeviceDescription> & get_registry() {
-        static map<string, DeviceDescription> device_registry;
+    static std::map<std::string, DeviceDescription> & get_registry() {
+        static std::map<std::string, DeviceDescription> device_registry;
         return device_registry;
     }
 };

--- a/devices/ioctrl/amic.cpp
+++ b/devices/ioctrl/amic.cpp
@@ -756,7 +756,7 @@ DmaPullResult AmicSerialXmitDma::pull_data(uint32_t req_len, uint32_t *avail_len
     return DmaPullResult::NoMoreData;
 };
 
-static vector<string> Amic_Subdevices = {
+static std::vector<std::string> Amic_Subdevices = {
     "ScsiCurio", "Sc53C94", "Escc", "Mace", "ViaCuda", "Swim3"
 };
 

--- a/devices/ioctrl/grandcentral.cpp
+++ b/devices/ioctrl/grandcentral.cpp
@@ -528,7 +528,7 @@ void GrandCentral::clear_cpu_int() {
     }
 }
 
-static const vector<string> GCSubdevices = {
+static const std::vector<std::string> GCSubdevices = {
     "NVRAM", "ViaCuda", "Escc", "ScsiCurio", "Sc53C94", "Mace", "Swim3"
 };
 

--- a/devices/ioctrl/ohare.cpp
+++ b/devices/ioctrl/ohare.cpp
@@ -296,7 +296,7 @@ void OHare::clear_cpu_int()
     }
 }
 
-static const vector<string> OHare_Subdevices = {
+static const std::vector<std::string> OHare_Subdevices = {
     "NVRAM", "ViaCuda", "ScsiMesh", "MeshHeathrow", "Escc", "Swim3"
 };
 

--- a/devices/memctrl/platinum.cpp
+++ b/devices/memctrl/platinum.cpp
@@ -501,7 +501,7 @@ void PlatinumCtrl::update_irq(uint8_t irq_line_state, uint8_t irq_mask) {
 // ========================== Device registry stuff ==========================
 static const PropMap Platinum_Properties = {
     {"gfxmem_size",
-        new IntProperty(1, vector<uint32_t>({1, 2, 4}))},
+        new IntProperty(1, std::vector<uint32_t>({1, 2, 4}))},
     {"mon_id",
         new StrProperty("HiRes12-14in")},
 };

--- a/devices/serial/escc.cpp
+++ b/devices/serial/escc.cpp
@@ -477,7 +477,7 @@ void EsccChannel::dma_flush_rx()
     });
 }
 
-static const vector<string> CharIoBackends = {"null", "stdio", "socket"};
+static const std::vector<std::string> CharIoBackends = {"null", "stdio", "socket"};
 
 static const PropMap Escc_Properties = {
     {"serial_backend", new StrProperty("null", CharIoBackends)},

--- a/devices/video/atimach64gx.cpp
+++ b/devices/video/atimach64gx.cpp
@@ -923,7 +923,7 @@ void AtiMach64Gx::rgb514_write_ind_reg(uint8_t reg_addr, uint8_t value)
 
 static const PropMap AtiMach64gx_Properties = {
     {"gfxmem_size",
-        new IntProperty(  2, vector<uint32_t>({2, 4, 6}))},
+        new IntProperty(  2, std::vector<uint32_t>({2, 4, 6}))},
     {"mon_id",
         new StrProperty("")},
 };

--- a/devices/video/atirage.cpp
+++ b/devices/video/atirage.cpp
@@ -932,7 +932,7 @@ int ATIRage::device_postinit()
 
 static const PropMap AtiRage_Properties = {
     {"gfxmem_size",
-        new IntProperty(  2, vector<uint32_t>({2, 4, 6}))},
+        new IntProperty(  2, std::vector<uint32_t>({2, 4, 6}))},
     {"mon_id",
         new StrProperty("")},
 };

--- a/devices/video/control.cpp
+++ b/devices/video/control.cpp
@@ -685,9 +685,9 @@ void ControlVideo::disable_display()
 
 static const PropMap Control_Properties = {
     {"gfxmem_banks",
-        new IntProperty(3, vector<uint32_t>({0, 1, 2, 3}))},
+        new IntProperty(3, std::vector<uint32_t>({0, 1, 2, 3}))},
     {"gfxmem_size",
-        new IntProperty(4, vector<uint32_t>({0, 2, 4}))},
+        new IntProperty(4, std::vector<uint32_t>({0, 2, 4}))},
     {"mon_id",
         new StrProperty("AppleVision1710")},
 };

--- a/machines/machinecatalyst.cpp
+++ b/machines/machinecatalyst.cpp
@@ -107,20 +107,20 @@ int initialize_catalyst(std::string& id)
 
 static const PropMap pm7200_settings = {
     {"rambank1_size",
-        new IntProperty(16, vector<uint32_t>({4, 8, 16, 32, 64, 128}))},
+        new IntProperty(16, std::vector<uint32_t>({4, 8, 16, 32, 64, 128}))},
     {"rambank2_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"rambank3_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"rambank4_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"emmo",
         new BinProperty(0)},
     {"cpu",
-        new StrProperty("601", vector<std::string>({"601", "750"}))},
+        new StrProperty("601", std::vector<std::string>({"601", "750"}))},
 };
 
-static vector<string> pm7200_devices = {
+static std::vector<std::string> pm7200_devices = {
     "Platinum", "Bandit1", "GrandCentral"
 };
 

--- a/machines/machinefactory.h
+++ b/machines/machinefactory.h
@@ -35,16 +35,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
-using namespace std;
-
 struct DeviceDescription;
 
 struct MachineDescription {
-    string                  name;
-    string                  description;
-    vector<string>          devices;
-    PropMap                 settings;
-    function<int(string&)>  init_func;
+    std::string                       name;
+    std::string                       description;
+    std::vector<std::string>          devices;
+    PropMap                           settings;
+    std::function<int(std::string&)>  init_func;
 };
 
 typedef std::function<std::optional<std::string>(const std::string&)> GetSettingValueFunc;
@@ -54,12 +52,12 @@ class MachineFactory
 public:
     MachineFactory() = delete;
 
-    static bool add(const string& machine_id, MachineDescription desc);
+    static bool add(const std::string& machine_id, MachineDescription desc);
 
-    static string machine_name_from_rom(string& rom_filepath);
+    static std::string machine_name_from_rom(std::string& rom_filepath);
 
-    static int create(string& mach_id);
-    static int create_machine_for_id(string& id, string& rom_filepath);
+    static int create(std::string& mach_id);
+    static int create_machine_for_id(std::string& id, std::string& rom_filepath);
 
     static void register_device_settings(const std::string &name);
     static int  register_machine_settings(const std::string& id);
@@ -70,14 +68,14 @@ public:
     static GetSettingValueFunc get_setting_value;
 
 private:
-    static void create_device(string& dev_name, DeviceDescription& dev);
+    static void create_device(std::string& dev_name, DeviceDescription& dev);
     static void print_settings(const PropMap& p);
     static void list_device_settings(DeviceDescription& dev);
-    static int  load_boot_rom(string& rom_filepath);
+    static int  load_boot_rom(std::string& rom_filepath);
     static void register_settings(const PropMap& p);
 
-    static map<string, MachineDescription> & get_registry() {
-        static map<string, MachineDescription> machine_registry;
+    static std::map<std::string, MachineDescription> & get_registry() {
+        static std::map<std::string, MachineDescription> machine_registry;
         return machine_registry;
     }
 };

--- a/machines/machinegazelle.cpp
+++ b/machines/machinegazelle.cpp
@@ -98,18 +98,18 @@ int initialize_gazelle(std::string& id)
 
 static const PropMap pm6500_settings = {
     {"rambank1_size",
-        new IntProperty(16, vector<uint32_t>({4, 8, 16, 32, 64, 128}))},
+        new IntProperty(16, std::vector<uint32_t>({4, 8, 16, 32, 64, 128}))},
     {"rambank2_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"rambank3_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"rambank4_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"emmo",
         new BinProperty(0)},
 };
 
-static vector<string> pm6500_devices = {
+static std::vector<std::string> pm6500_devices = {
     "Psx", "PsxPci1", "OHare"
 };
 

--- a/machines/machinegossamer.cpp
+++ b/machines/machinegossamer.cpp
@@ -167,11 +167,11 @@ int initialize_gossamer(std::string& id)
 
 static const PropMap gossamer_settings = {
     {"rambank1_size",
-        new IntProperty(256, vector<uint32_t>({8, 16, 32, 64, 128, 256}))},
+        new IntProperty(256, std::vector<uint32_t>({8, 16, 32, 64, 128, 256}))},
     {"rambank2_size",
-        new IntProperty(  0, vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
+        new IntProperty(  0, std::vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
     {"rambank3_size",
-        new IntProperty(  0, vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
+        new IntProperty(  0, std::vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
     {"emmo",
         new BinProperty(0)},
     {"hdd_config",
@@ -180,11 +180,11 @@ static const PropMap gossamer_settings = {
         new StrProperty("Ide1:0")},
 };
 
-static vector<string> pmg3_devices = {
+static std::vector<std::string> pmg3_devices = {
     "Grackle", "ScreamerSnd", "Heathrow", "AtaHardDisk", "AtapiCdrom"
 };
 
-static vector<string> pmg3twr_devices = {
+static std::vector<std::string> pmg3twr_devices = {
     "Grackle", "ScreamerSnd", "Heathrow", "AtaHardDisk", "AtapiCdrom"
 };
 

--- a/machines/machinepdm.cpp
+++ b/machines/machinepdm.cpp
@@ -97,7 +97,7 @@ int initialize_pdm(std::string& id)
 
 // Monitors supported by the PDM on-board video.
 // see displayid.cpp for the full list of supported monitor IDs.
-static const vector<string> PDMBuiltinMonitorIDs = {
+static const std::vector<std::string> PDMBuiltinMonitorIDs = {
     "PortraitGS", "MacRGB12in", "MacRGB15in", "HiRes12-14in", "VGA-SVGA",
     "MacRGB16in", "Multiscan15in", "Multiscan17in", "Multiscan20in",
     "NotConnected"
@@ -105,16 +105,16 @@ static const vector<string> PDMBuiltinMonitorIDs = {
 
 static const PropMap pm6100_settings = {
     {"rambank1_size",
-        new IntProperty(0, vector<uint32_t>({0, 2, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty(0, std::vector<uint32_t>({0, 2, 4, 8, 16, 32, 64, 128}))},
     {"rambank2_size",
-        new IntProperty(0, vector<uint32_t>({0, 2, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty(0, std::vector<uint32_t>({0, 2, 4, 8, 16, 32, 64, 128}))},
     {"mon_id",
         new StrProperty("HiRes12-14in", PDMBuiltinMonitorIDs)},
     {"emmo",
         new BinProperty(0)},
 };
 
-static vector<string> pm6100_devices = {
+static std::vector<std::string> pm6100_devices = {
     "HMC", "Amic"
 };
 

--- a/machines/machinepippin.cpp
+++ b/machines/machinepippin.cpp
@@ -74,20 +74,20 @@ int initialize_pippin(std::string& id) {
 
 static const PropMap Pippin_Settings = {
     {"rambank1_size",
-        new IntProperty(4, vector<uint32_t>({4}))}, // fixed size
+        new IntProperty(4, std::vector<uint32_t>({4}))}, // fixed size
     {"rambank2_size",
-        new IntProperty(1, vector<uint32_t>({1}))}, // fixed size
+        new IntProperty(1, std::vector<uint32_t>({1}))}, // fixed size
     {"rambank3_size",
-        new IntProperty(0, vector<uint32_t>({0, 1, 4, 8, 16}))},
+        new IntProperty(0, std::vector<uint32_t>({0, 1, 4, 8, 16}))},
     {"rambank4_size",
-        new IntProperty(0, vector<uint32_t>({0, 1, 4, 8, 16}))},
+        new IntProperty(0, std::vector<uint32_t>({0, 1, 4, 8, 16}))},
     {"emmo",
         new BinProperty(0)},
     {"adb_devices",
         new StrProperty("AppleJack,Keyboard")},
 };
 
-static vector<string> Pippin_Devices = {
+static std::vector<std::string> Pippin_Devices = {
     "Aspen", "AspenPci1", "ScsiMesh", "MeshTnt", "GrandCentral", "TaosVideo"
 };
 

--- a/machines/machineproperties.cpp
+++ b/machines/machineproperties.cpp
@@ -81,18 +81,18 @@ uint32_t IntProperty::get_int()
             LOG_F(ERROR, "Invalid property value %d!", result);
             LOG_F(ERROR, "Valid values: %s!",
                 this->get_valid_values_as_str().c_str());
-            this->set_string(to_string(this->int_val));
+            this->set_string(std::to_string(this->int_val));
         } else {
             this->int_val = result;
         }
-    } catch (string bad_string) {
+    } catch (std::string bad_string) {
         LOG_F(ERROR, "Could not convert string %s to an integer!",
             bad_string.c_str());
     }
     return this->int_val;
 }
 
-string IntProperty::get_valid_values_as_str()
+std::string IntProperty::get_valid_values_as_str()
 {
     std::stringstream ss;
 
@@ -133,7 +133,7 @@ bool IntProperty::check_val(uint32_t val)
     }
 }
 
-void BinProperty::set_string(string val)
+void BinProperty::set_string(std::string val)
 {
     if ((val.compare("ON") == 0) || (val.compare("on") == 0) || (val.compare("1") == 0) || (val.compare("yes") == 0)) {
         this->bin_val = 1;
@@ -146,19 +146,19 @@ void BinProperty::set_string(string val)
     }
 }
 
-void parse_device_path(string dev_path, string& bus_id, uint32_t& dev_num) {
+void parse_device_path(std::string dev_path, std::string& bus_id, uint32_t& dev_num) {
     bus_id  = "";
     dev_num = -1;
 
     size_t delimiter_pos = dev_path.find(":");
-    if (delimiter_pos == string::npos)
+    if (delimiter_pos == std::string::npos)
         ABORT_F("Invalid device path %s", dev_path.c_str());
 
     bus_id = dev_path.substr(0, delimiter_pos);
 
     try {
         dev_num = (uint32_t)strtoul(dev_path.substr(delimiter_pos+1).c_str(), 0, 0);
-    } catch (string bad_string) {
+    } catch (std::string bad_string) {
         ABORT_F("Invalid device number %s in device path %s", bad_string.c_str(),
             dev_path.c_str());
     }

--- a/machines/machineproperties.h
+++ b/machines/machineproperties.h
@@ -29,8 +29,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef MACHINE_PROPERTIES_H
 #define MACHINE_PROPERTIES_H
 
-using namespace std;
-
 /** Property types. */
 enum PropType : int {
     PROP_TYPE_UNKNOWN   = 0,
@@ -49,7 +47,7 @@ enum CheckType : int {
 /** Abstract base class for properties. */
 class BasicProperty {
 public:
-    BasicProperty(PropType type, string val) {
+    BasicProperty(PropType type, std::string val) {
         this->type = type;
         set_string(val);
     }
@@ -59,11 +57,11 @@ public:
     /* Clone method for copying derived property objects. */
     virtual BasicProperty* clone() const = 0;
 
-    virtual string get_string() {
+    virtual std::string get_string() {
         return this->val;
     }
 
-    virtual void set_string(string str) {
+    virtual void set_string(std::string str) {
         this->val = str;
     }
 
@@ -72,15 +70,15 @@ public:
     }
 
 protected:
-    PropType    type;
-    string      val;
+    PropType         type;
+    std::string      val;
 };
 
 
 /** Property class that holds a string value. */
 class StrProperty : public BasicProperty {
 public:
-    StrProperty(string str)
+    StrProperty(std::string str)
         : BasicProperty(PROP_TYPE_STRING, str)
     {
         this->check_type = CHECK_TYPE_NONE;
@@ -88,7 +86,7 @@ public:
     }
 
     /* construct a string property with a list of valid values. */
-    StrProperty(string str, vector<string> vec)
+    StrProperty(std::string str, std::vector<std::string> vec)
         : BasicProperty(PROP_TYPE_STRING, str)
     {
         this->check_type = CHECK_TYPE_LIST;
@@ -98,16 +96,16 @@ public:
     BasicProperty* clone() const { return new StrProperty(*this); }
 
     /* override BasicProperty::set_string() and perform checks */
-    void set_string(string str);
+    void set_string(std::string str);
 
-    string get_valid_values_as_str();
+    std::string get_valid_values_as_str();
 
 protected:
-    bool check_val(string str);
+    bool check_val(std::string str);
 
 private:
-    CheckType       check_type;
-    vector<string>  vec;
+    CheckType                 check_type;
+    std::vector<std::string>  vec;
 };
 
 /** Property class that holds an integer value. */
@@ -115,7 +113,7 @@ class IntProperty : public BasicProperty {
 public:
     /* construct an integer property without value check. */
     IntProperty(uint32_t val)
-        : BasicProperty(PROP_TYPE_INTEGER, to_string(val))
+        : BasicProperty(PROP_TYPE_INTEGER, std::to_string(val))
     {
         this->int_val    = val;
         this->min        = std::numeric_limits<uint32_t>::min();
@@ -126,7 +124,7 @@ public:
 
     /* construct an integer property with a predefined range. */
     IntProperty(uint32_t val, uint32_t min, uint32_t max)
-        : BasicProperty(PROP_TYPE_INTEGER, to_string(val))
+        : BasicProperty(PROP_TYPE_INTEGER, std::to_string(val))
     {
         this->int_val    = val;
         this->min        = min;
@@ -136,8 +134,8 @@ public:
     }
 
     /* construct an integer property with a list of valid values. */
-    IntProperty(uint32_t val, vector<uint32_t> vec)
-        : BasicProperty(PROP_TYPE_INTEGER, to_string(val))
+    IntProperty(uint32_t val, std::vector<uint32_t> vec)
+        : BasicProperty(PROP_TYPE_INTEGER, std::to_string(val))
     {
         this->int_val    = val;
         this->min        = std::numeric_limits<uint32_t>::min();
@@ -150,17 +148,17 @@ public:
 
     uint32_t get_int();
 
-    string get_valid_values_as_str();
+    std::string get_valid_values_as_str();
 
 protected:
     bool check_val(uint32_t val);
 
 private:
-    uint32_t            int_val;
-    CheckType           check_type;
-    uint32_t            min;
-    uint32_t            max;
-    vector<uint32_t>    vec;
+    uint32_t                 int_val;
+    CheckType                check_type;
+    uint32_t                 min;
+    uint32_t                 max;
+    std::vector<uint32_t>    vec;
 };
 
 /** Property class that holds a binary value. */
@@ -175,10 +173,10 @@ public:
     BasicProperty* clone() const { return new BinProperty(*this); }
 
     // override BasicProperty::set_string() and perform checks
-    void set_string(string str);
+    void set_string(std::string str);
 
-    string get_valid_values_as_str() {
-        return string("on, off, ON, OFF");
+    std::string get_valid_values_as_str() {
+        return std::string("on, off, ON, OFF");
     };
 
     int get_val() { return this->bin_val; };
@@ -187,13 +185,13 @@ private:
     int     bin_val;
 };
 
-void parse_device_path(string dev_path, string& bus_id, uint32_t& dev_num);
+void parse_device_path(std::string dev_path, std::string& bus_id, uint32_t& dev_num);
 
 /** Special map type for specifying machine presets. */
-typedef map<string, BasicProperty*> PropMap;
+typedef std::map<std::string, BasicProperty*> PropMap;
 
 /** Global map that holds settings for the running machine. */
-extern map<string, unique_ptr<BasicProperty>> gMachineSettings;
+extern std::map<std::string, std::unique_ptr<BasicProperty>> gMachineSettings;
 
 /** Conveniency macros to hide complex casts. */
 #define SET_STR_PROP(name, value) \

--- a/machines/machinetnt.cpp
+++ b/machines/machinetnt.cpp
@@ -154,13 +154,13 @@ int initialize_tnt(std::string& id)
 template <uint32_t cpu>
 static const PropMap pm7500_settings = {
     {"rambank1_size",
-        new IntProperty(16, vector<uint32_t>({4, 8, 16, 32, 64, 128}))},
+        new IntProperty(16, std::vector<uint32_t>({4, 8, 16, 32, 64, 128}))},
     {"rambank2_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"rambank3_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"rambank4_size",
-        new IntProperty( 0, vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
+        new IntProperty( 0, std::vector<uint32_t>({0, 4, 8, 16, 32, 64, 128}))},
     {"emmo",
         new BinProperty(0)},
     {"cpu",
@@ -168,22 +168,22 @@ static const PropMap pm7500_settings = {
             cpu == PPC_VER::MPC601  ? "601" :
             cpu == PPC_VER::MPC604  ? "604" :
             cpu == PPC_VER::MPC604E ? "604e" :
-            "604e", vector<std::string>({"601", "604", "604e", "750"})
+            "604e", std::vector<std::string>({"601", "604", "604e", "750"})
         )
     },
 };
 
-static vector<string> pm7500_devices = {
+static std::vector<std::string> pm7500_devices = {
     "Hammerhead", "Bandit1", "Chaos", "ScsiMesh", "MeshTnt", "GrandCentral",
     "ControlVideo"
 };
 
-static vector<string> pm8500_devices = {
+static std::vector<std::string> pm8500_devices = {
     "Hammerhead", "Bandit1", "Chaos", "ScsiMesh", "MeshTnt", "GrandCentral",
     "ControlVideo", "Sixty6Video"
 };
 
-static vector<string> pm9500_devices = {
+static std::vector<std::string> pm9500_devices = {
     "Hammerhead", "Bandit1", "Bandit2", "ScsiMesh", "MeshTnt", "GrandCentral"
 };
 

--- a/machines/machineyosemite.cpp
+++ b/machines/machineyosemite.cpp
@@ -108,13 +108,13 @@ int initialize_yosemite(std::string& id)
 
 static const PropMap yosemite_settings = {
     {"rambank1_size",
-        new IntProperty(256, vector<uint32_t>({8, 16, 32, 64, 128, 256}))},
+        new IntProperty(256, std::vector<uint32_t>({8, 16, 32, 64, 128, 256}))},
     {"rambank2_size",
-        new IntProperty(  0, vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
+        new IntProperty(  0, std::vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
     {"rambank3_size",
-        new IntProperty(  0, vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
+        new IntProperty(  0, std::vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
     {"rambank4_size",
-        new IntProperty(  0, vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
+        new IntProperty(  0, std::vector<uint32_t>({0, 8, 16, 32, 64, 128, 256}))},
     {"emmo",
         new BinProperty(0)},
     {"hdd_config",
@@ -123,7 +123,7 @@ static const PropMap yosemite_settings = {
         new StrProperty("Ide0:0")},
 };
 
-static vector<string> yosemite_devices = {
+static std::vector<std::string> yosemite_devices = {
     "Grackle",
     "Dec21154Yosemite",
     "CmdAta",


### PR DESCRIPTION
It's somewhat of an anti-pattern, and can lead to conflicts with other symbols (e.g. the Windows build failure in https://github.com/dingusdev/dingusppc/actions/runs/11762906342/job/32766290288, I removed `using namespace std` from timermanager.h to fix that one).