### PR TITLE
Respect FP bit in MSR when running floating point instructions

### DIFF
--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -646,6 +646,8 @@ extern void ppc_exec_single(void);
 extern void ppc_exec_until(uint32_t goal_addr);
 extern void ppc_exec_dbg(uint32_t start_addr, uint32_t size);
 
+extern void ppc_msr_did_change();
+
 /* debugging support API */
 void print_fprs(void);                   /* print content of the floating-point registers  */
 uint64_t get_reg(std::string reg_name); /* get content of the register reg_name */

--- a/cpu/ppc/ppcexceptions.cpp
+++ b/cpu/ppc/ppcexceptions.cpp
@@ -117,6 +117,7 @@ void ppc_exception_handler(Except_Type exception_type, uint32_t srr1_bits) {
     ppc_state.msr &= 0xFFFB1041;
     /* copy MSR[ILE] to MSR[LE] */
     ppc_state.msr = (ppc_state.msr & ~MSR::LE) | !!(ppc_state.msr & MSR::ILE);
+    ppc_msr_did_change();
 
     if (ppc_state.msr & MSR::IP) {
         ppc_next_instruction_address |= 0xFFF00000;

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -802,6 +802,7 @@ void dppc_interpreter::ppc_mtmsr(uint32_t opcode) {
     }
     uint32_t reg_s = (opcode >> 21) & 0x1F;
     ppc_state.msr = ppc_state.gpr[reg_s];
+    ppc_msr_did_change();
 
     // generate External Interrupt Exception
     // if CPU interrupt line is asserted
@@ -1379,6 +1380,7 @@ void dppc_interpreter::ppc_rfi(uint32_t opcode) {
     uint32_t new_srr1_val   = (ppc_state.spr[SPR::SRR1] & 0x87C0FF73UL);
     uint32_t new_msr_val    = (ppc_state.msr & ~0x87C0FF73UL);
     ppc_state.msr           = (new_msr_val | new_srr1_val) & 0xFFFBFFFFUL;
+    ppc_msr_did_change();
 
     // generate External Interrupt Exception
     // if CPU interrupt line is still asserted


### PR DESCRIPTION
Rather than running them normally, they should trigger a "no FPU" exception. This appears to be required to allow correct graphical rendering under Mac OS X - the FP bit cleared via `mtmsr` and `rfi` instructions and something else appears to be relying on the exception to be thrown.

Implemented by maintaining a parallel version of the `OpcodeGrabber` table (`OpcodeGrabberNoFPU`) which contains alternate implementations for all the floating point instructions. We switch the table whenever the MSR value changes. This should minimize the overhead of doing these checks.