### PR TITLE
Mitigate performance impact of respecting FP bit

### DIFF
--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -182,9 +182,10 @@ extern uint32_t rtc_lo, rtc_hi;
 
 /* Flags for controlling interpreter execution. */
 enum {
-    EXEF_BRANCH    = 1 << 0,
-    EXEF_EXCEPTION = 1 << 1,
-    EXEF_RFI       = 1 << 2,
+    EXEF_BRANCH         = 1 << 0, // Branch taken, target PC is is in ppc_next_instruction_address
+    EXEF_EXCEPTION      = 1 << 1, // Exception handler invoked
+    EXEF_RFI            = 1 << 2, // RFI instruction executed
+    EXEF_OPC_DECODER    = 1 << 3, // Opcode decoder has changed
 };
 
 enum CR_select : int32_t {
@@ -640,13 +641,14 @@ template <field_rc rec> extern void power_srq(uint32_t opcode);
 
 extern uint64_t get_virt_time_ns(void);
 
-extern void ppc_main_opcode(uint32_t opcode);
+extern void ppc_main_opcode(PPCOpcode* ppc_opcode_grabber, uint32_t opcode);
 extern void ppc_exec(void);
 extern void ppc_exec_single(void);
 extern void ppc_exec_until(uint32_t goal_addr);
 extern void ppc_exec_dbg(uint32_t start_addr, uint32_t size);
 
-extern void ppc_msr_did_change();
+extern PPCOpcode *ppc_opcode_grabber();
+extern void ppc_msr_did_change(uint32_t old_msr_val, bool set_next_instruction_address = true);
 
 /* debugging support API */
 void print_fprs(void);                   /* print content of the floating-point registers  */

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -801,8 +801,9 @@ void dppc_interpreter::ppc_mtmsr(uint32_t opcode) {
         ppc_exception_handler(Except_Type::EXC_PROGRAM, Exc_Cause::NOT_ALLOWED);
     }
     uint32_t reg_s = (opcode >> 21) & 0x1F;
+    uint32_t old_msr_val = ppc_state.msr;
     ppc_state.msr = ppc_state.gpr[reg_s];
-    ppc_msr_did_change();
+    ppc_msr_did_change(old_msr_val);
 
     // generate External Interrupt Exception
     // if CPU interrupt line is asserted
@@ -1377,10 +1378,11 @@ void dppc_interpreter::ppc_rfi(uint32_t opcode) {
 #ifdef CPU_PROFILING
     num_supervisor_instrs++;
 #endif
+    uint32_t old_msr_val    = ppc_state.msr;
     uint32_t new_srr1_val   = (ppc_state.spr[SPR::SRR1] & 0x87C0FF73UL);
     uint32_t new_msr_val    = (ppc_state.msr & ~0x87C0FF73UL);
     ppc_state.msr           = (new_msr_val | new_srr1_val) & 0xFFFBFFFFUL;
-    ppc_msr_did_change();
+    ppc_msr_did_change(old_msr_val);
 
     // generate External Interrupt Exception
     // if CPU interrupt line is still asserted
@@ -1406,7 +1408,7 @@ void dppc_interpreter::ppc_rfi(uint32_t opcode) {
 
     mmu_change_mode();
 
-    exec_flags = EXEF_RFI;
+    exec_flags |= EXEF_RFI;
 }
 
 void dppc_interpreter::ppc_sc(uint32_t opcode) {

--- a/cpu/ppc/test/ppctests.cpp
+++ b/cpu/ppc/test/ppctests.cpp
@@ -46,7 +46,7 @@ void xer_ov_test(string mnem, uint32_t opcode) {
     ppc_state.gpr[3]        = 2;
     ppc_state.gpr[4]        = 2;
     ppc_state.spr[SPR::XER] = 0xFFFFFFFF;
-    ppc_main_opcode(opcode);
+    ppc_main_opcode(ppc_opcode_grabber(), opcode);
     if (ppc_state.spr[SPR::XER] & 0x40000000UL) {
         cout << "Invalid " << mnem << " emulation! XER[OV] should not be set." << endl;
         nfailed++;
@@ -150,7 +150,7 @@ static void read_test_data() {
         ppc_state.spr[SPR::XER] = 0;
         ppc_state.cr            = 0;
 
-        ppc_main_opcode(opcode);
+        ppc_main_opcode(ppc_opcode_grabber(), opcode);
 
         ntested++;
 
@@ -292,7 +292,7 @@ static void read_test_float_data() {
 
         ppc_state.cr = 0;
 
-        ppc_main_opcode(opcode);
+        ppc_main_opcode(ppc_opcode_grabber(), opcode);
 
         ntested++;
 
@@ -318,6 +318,9 @@ static void read_test_float_data() {
 int main() {
     is_601 = true;
     initialize_ppc_opcode_table(); //kludge
+    // MPC601 sets MSR[ME] bit during hard reset / Power-On.
+    // Also set MSR[FP] bit so we can test FPU instructions.
+    ppc_state.msr = (MSR::ME | MSR::IP | MSR::FP);
 
     cout << "Running DingusPPC emulator tests..." << endl << endl;
 


### PR DESCRIPTION
In #135 we switched from a static `OpcodeGrabber` table to a `curOpcodeGrabber` pointer in `ppc_main_opcode`. This results in an extra indirection (as far as generated assembly having an additional load), which reduces execution speed.

Switch to making the opcode grabber into a parameter to `ppc_main_opcode`, and make `ppc_exec_inner` keep it up to date (via an `EXEF_OPCODE` exception flag). 

Also fixes FPU instructions in `ppctests` - we now need to set the FP MSR bit when initializing the CPU.