### PR TITLE
Add CLI flag to allow setting of OpenFirmware environment variables

### DIFF
--- a/debugger/debugger.cpp
+++ b/debugger/debugger.cpp
@@ -784,9 +784,15 @@ void DppcDebugger::enter_debugger() {
             ss >> var_name;
             std::istream::sentry se(ss); // skip white space
             getline(ss, value); // get everything up to eol
-            if (ofnvram->init())
+            if (ofnvram->init()) {
+                cout << " Cannot open NVRAM" << endl;
                 continue;
-            ofnvram->setenv(var_name, value);
+            }
+            if (!ofnvram->setenv(var_name, value)) {
+                cout << " Please try again" << endl;
+            } else {
+                cout << " ok" << endl; // mimic Forth
+            }
  #ifndef _WIN32
         } else if (cmd == "nvedit") {
             cmd = "";

--- a/devices/common/ofnvram.cpp
+++ b/devices/common/ofnvram.cpp
@@ -322,6 +322,9 @@ bool OfConfigChrp::validate()
     bool    wip = true;
     bool    of_part_found = false;
 
+    if (this->nvram_obj == nullptr)
+        return false;
+
     // search the entire 8KB NVRAM for CHRP OF config partition.
     // Bail out if an unknown partition or free space is encountered.
     // Skip over known partitions.
@@ -592,16 +595,12 @@ void OfConfigUtils::printenv() {
     }
 }
 
-void OfConfigUtils::setenv(string var_name, string value)
+bool OfConfigUtils::setenv(string var_name, string value)
 {
     if (!this->open_container())
-        return;
+        return false;
 
     OfConfigImpl::config_dict vars = this->cfg_impl->get_config_vars();
 
-    if (!this->cfg_impl->set_var(var_name, value)) {
-        cout << " Please try again" << endl;
-    } else {
-        cout << " ok" << endl; // mimic Forth
-    }
+    return this->cfg_impl->set_var(var_name, value);
 }

--- a/devices/common/ofnvram.h
+++ b/devices/common/ofnvram.h
@@ -134,7 +134,7 @@ public:
 
     int  init();
     void printenv();
-    void setenv(std::string var_name, std::string value);
+    bool setenv(std::string var_name, std::string value);
 
 protected:
     bool open_container();


### PR DESCRIPTION
Allows enabling of verbose booting via the command-line interface (instead of having to drop into the interactive debugger).