### PR TITLE
Fix build fail on linux/libstdc++

### DIFF
--- a/devices/memctrl/psx.cpp
+++ b/devices/memctrl/psx.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <cinttypes>
 #include <string>
+#include <algorithm>
 
 PsxCtrl::PsxCtrl(int bridge_num, std::string name)
 {


### PR DESCRIPTION
Just a single missing `#include` for `std::remove_if`.