### PR TITLE
Add INI config file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ compile_commands.json
 # Ignore generated executables
 dingusppc
 dingusppc.exe
+dingusppc.ini
 
 # Ignore system files
 .DS_Store


### PR DESCRIPTION
Add support for reading and writing INI configuration files using CLI11's built-in config infrastructure.

### New options

- **`-c, --config <file>`** — Load settings from an INI file (defaults to `dingusppc.ini` in the working directory). The file is optional; if it doesn't exist, it's silently ignored.
- **`--write-config [file]`** — Export the current configuration (including any CLI overrides and machine properties) to an INI file and exit. Defaults to `dingusppc.ini`.

### Example workflow

```sh
# Save a config with machine properties
dingusppc --machine pmg3dt --ramsize=128 --write-config

# Launch using saved config
dingusppc
# or explicitly:
dingusppc -c dingusppc.ini
```

### Changes

- Enable `config_extras_mode::capture` so machine-specific properties (which are registered late) pass through to the config file and are available for lookup.
- Rewrite `get_setting_value` to look up properties from `app.remaining()` directly, handling `--key=value`, `--key value` (CLI), and bare `key value` pairs (config file).
- Mark `--log-verbosity` and `--write-config` as non-configurable so they don't round-trip into the INI file.
- Add `dingusppc.ini` to .gitignore.