### PR TITLE
Add icnt_factor and g_realtime keyboard shortcuts

### DIFF
--- a/core/hostevents_sdl.cpp
+++ b/core/hostevents_sdl.cpp
@@ -125,6 +125,35 @@ void EventManager::poll_events() {
                     }
                     return;
                 }
+                // LAlt-+: speed up icnt_factor
+                if (event.key.keysym.sym == SDLK_EQUALS && (event.key.keysym.mod & KMOD_ALL) == KMOD_LALT) {
+                    if (event.type == SDL_KEYUP) {
+                        int icnt_counter_val = increment_icnt_factor();
+                        LOG_F(INFO, "Incremented icnt_factor: %d", icnt_counter_val);
+                    }
+                    return;
+                }
+                // LAlt--: slow down icnt_factor
+                if (event.key.keysym.sym == SDLK_MINUS && (event.key.keysym.mod & KMOD_ALL) == KMOD_LALT) {
+                    if (event.type == SDL_KEYUP) {
+                        int icnt_counter_val = decrement_icnt_factor();
+                        LOG_F(INFO, "Decremented icnt_factor: %d", icnt_counter_val);
+                    }
+                    return;
+                }
+
+                // LALT-R: g_realtime toggle
+                if (event.key.keysym.sym == SDLK_r && (event.key.keysym.mod & KMOD_ALL) == KMOD_LALT) {
+                    if (event.type == SDL_KEYUP) {
+                        bool g_realtime_status = toggle_g_realtime();
+                        if (g_realtime_status == true) {
+                            LOG_F(INFO, "g_realtime: enabled");
+                        } else if (g_realtime_status == false) {
+                            LOG_F(INFO, "g_realtime: disabled");
+                        }
+                    }
+                }
+
                 // Control-L: log toggle
                 if (event.key.keysym.sym == SDLK_l && (event.key.keysym.mod & KMOD_ALL) == KMOD_LCTRL) {
                     if (event.type == SDL_KEYUP) {

--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -691,4 +691,15 @@ extern void ppc_msr_did_change(uint32_t old_msr_val, uint32_t new_msr_val, bool 
 uint64_t get_reg(std::string reg_name); /* get content of the register reg_name */
 void set_reg(std::string reg_name, uint64_t val); /* set reg_name to val */
 
+/* icnt_factor control */
+extern int increment_icnt_factor();
+extern int decrement_icnt_factor();
+extern int get_icnt_factor();
+
+/* toggle_g_realtime */
+extern bool toggle_g_realtime();
+
+/* force_cycle_counter_reload */
+static void force_cycle_counter_reload();
+
 #endif /* PPCEMU_H */

--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -81,7 +81,7 @@ bool dec_exception_pending = false;
 uint32_t    glob_bb_start_la;
 
 /* variables related to virtual time */
-const bool g_realtime = false;
+bool g_realtime = false;
 uint64_t g_nanoseconds_base;
 uint64_t g_icycles;
 int      icnt_factor;
@@ -288,6 +288,35 @@ static void force_cycle_counter_reload()
 {
     // tell the interpreter loop to reload cycle counter
     exec_timer = true;
+}
+
+int increment_icnt_factor()
+{
+    icnt_factor += 1;
+    force_cycle_counter_reload();
+    return icnt_factor;
+}
+
+int decrement_icnt_factor()
+{
+    icnt_factor -= 1;
+    force_cycle_counter_reload();
+    return icnt_factor;
+}
+
+int get_icnt_factor()
+{
+    return icnt_factor;
+}
+
+bool toggle_g_realtime()
+{
+    if (g_realtime == false)
+        g_realtime = true;
+    else if (g_realtime == true)
+        g_realtime = false;
+    force_cycle_counter_reload();
+    return g_realtime;
 }
 
 typedef enum {


### PR DESCRIPTION
Added controls to increment/decrement icnt_factor and toggle g_realtime for testing and debugging purposes.
LeftAlt - = -> increment_icnt_factor();
LeftAlt - - -> decrement_icnt_factor();
LeftAlt - r -> toggle_g_realtime();

I'm using LeftAlt as the modifier key to prevent accidental toggling and not conflict with Control shortcuts.