### PR TITLE
ppcexec: Emulate PowerPC sleep on MSR POW

### DIFF
--- a/cpu/ppc/ppcemu.h
+++ b/cpu/ppc/ppcemu.h
@@ -195,6 +195,7 @@ enum {
     EXEF_EXCEPTION      = 1 << 1, // Exception handler invoked
     EXEF_RFI            = 1 << 2, // RFI instruction executed
     EXEF_OPC_DECODER    = 1 << 3, // Opcode decoder has changed
+    EXEF_SLEEP          = 1 << 4, // Processor is waiting in power-saving mode
 };
 
 enum CR_select : int32_t {

--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -377,6 +377,19 @@ static void ppc_exec_inner(uint32_t start_addr, uint32_t size)
             max_cycles = process_events();
 
         if (exec_flags) {
+            if ((exec_flags & EXEF_SLEEP) && !(exec_flags & EXEF_EXCEPTION)) [[unlikely]] {
+                while (power_on && (exec_flags & EXEF_SLEEP)) {
+                    max_cycles = process_events();
+                    if (!(exec_flags & EXEF_SLEEP)) {
+                        break;
+                    }
+                    if (max_cycles > g_icycles) {
+                        g_icycles = max_cycles;
+                    } else {
+                        g_icycles++;
+                    }
+                }
+            }
             if (exec_flags & EXEF_OPC_DECODER) [[unlikely]] {
                 opcode_grabber = ppc_opcode_grabber;
             }

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -30,6 +30,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cinttypes>
 #include <vector>
 
+// MPC750 HID0 power-saving mode bits. They are selected in HID0, then
+// entered by setting MSR[POW] with mtmsr.
+static constexpr uint32_t HID0_DOZE  = 0x00800000;
+static constexpr uint32_t HID0_NAP   = 0x00400000;
+static constexpr uint32_t HID0_SLEEP = 0x00200000;
+static constexpr uint32_t HID0_POWER_SAVE_MASK = HID0_DOZE | HID0_NAP | HID0_SLEEP;
+
 //Extract the registers desired and the values of the registers.
 
 // Affects CR Field 0 - For integer operations
@@ -813,6 +820,10 @@ void dppc_interpreter::ppc_mtmsr(uint32_t opcode) {
         dec_exception_pending = false;
         //LOG_F(WARNING, "MTMSR: decrementer exception triggered");
         ppc_exception_handler(Except_Type::EXC_DECR, 0);
+    } else if ((ppc_state.msr & MSR::POW) &&
+               (ppc_state.spr[SPR::HID0] & HID0_POWER_SAVE_MASK)) {
+        exec_flags |= EXEF_SLEEP;
+        ppc_next_instruction_address = (ppc_state.pc & 0xFFFFFFFCUL) + 4;
     } else {
         mmu_change_mode();
     }


### PR DESCRIPTION
xnu-123.5 and similar vintage kernls enter the PowerPC 750 power save mode when the scheduler has no runnable work. `machine_idle_ppc` selects HID0 doze or nap, records a nap timestamp, then executes `mtmsr` with `MSR[POW]` set. It stays in a loop there (in case the power saving had no effect immediately) - it expects execution to resume at the `machine_idle_ret` label (when an interrupt occurs), which ends up returning from the function.

We model this state explicitly:
- When `mtmsr` sets `MSR[POW]` with the `HID0` doze/nap/sleep flags, set a new `EXEF_SLEEP` flag.
- While `EXEF_SLEEP` is set, keep processing host events without advancing the guest PC.

Towards getting the 10.0 public beta to boot (#154) - before this we would enter the DPPC debugger shortly after this instruction (due to a bogus MSR LE flag eventually being set). Now we make more progress and end up in a "Still waiting for root device" loop (presumably something at the ATA layer)