### PR TITLE
atapicdrom: fix spurious reads during Mac OS boot

### DIFF
--- a/devices/common/ata/atapicdrom.cpp
+++ b/devices/common/ata/atapicdrom.cpp
@@ -87,8 +87,14 @@ void AtapiCdrom::perform_packet_command() {
         LOG_F(WARNING, "%s: doing_sector_areas reset", this->name.c_str());
     }
 
-    // assume successful command execution
-    this->status_good();
+    // Assume successful command execution
+    if (this->cmd_pkt[0] == ScsiCommand::REQ_SENSE) {
+        // For REQ_SENSE we only set the status, status_good() also resets
+        // sense_key, which we'll need to return.
+        this->set_status(ScsiStatus::GOOD, 0);
+    } else {
+        this->status_good();
+    }
 
     switch (this->cmd_pkt[0]) {
     case ScsiCommand::READ_CD:

--- a/devices/common/ata/atapicdrom.h
+++ b/devices/common/ata/atapicdrom.h
@@ -39,6 +39,7 @@ public:
     }
 
     bool is_device_ready() override { return this->is_ready; }
+    uint8_t not_ready_reason() override { return ScsiError::MEDIUM_NOT_PRESENT; }
 
     int device_postinit() override;
 


### PR DESCRIPTION
Fixes a couple of regressions after the generic SCSI command refactor:
- `not_ready_reason` was missing an override, so we were not actually returning `MEDIUM_NOT_PRESENT`.
- `status_good()` was unconditionally called before every command, including for `REQ_SENSE`. It cleared `sense_key`, thus we were not returning the correct state back.