### PR TITLE
cpu: remove unused global variables

### DIFF
--- a/cpu/ppc/ppcexec.cpp
+++ b/cpu/ppc/ppcexec.cpp
@@ -92,11 +92,6 @@ volatile bool exec_timer;
 bool int_pin = false; // interrupt request pin state: true - asserted
 bool dec_exception_pending = false;
 
-/* copy of local variable bb_start_la. Need for correct
-   calculation of CPU cycles after setjmp that clobbers
-   non-volatile local variables. */
-uint32_t    glob_bb_start_la;
-
 /* variables related to virtual time */
 const bool g_realtime = false;
 uint64_t g_nanoseconds_base;

--- a/cpu/ppc/ppcmmu.cpp
+++ b/cpu/ppc/ppcmmu.cpp
@@ -77,9 +77,6 @@ uint64_t    num_entry_replacements  = 0; // number of entry replacements
 #endif // TLB_PROFILING
 
 /** remember recently used physical memory regions for quicker translation. */
-AddressMapEntry last_read_area;
-AddressMapEntry last_write_area;
-AddressMapEntry last_exec_area;
 AddressMapEntry last_ptab_area;
 
 /** Dummy pages for catching writes to physical read-only pages */
@@ -1955,9 +1952,6 @@ static void invalidate_tlb_entries(std::array<TLBEntry, N> &tlb) {
 
 void ppc_mmu_init()
 {
-    last_read_area  = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullptr};
-    last_write_area = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullptr};
-    last_exec_area  = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullptr};
     last_ptab_area  = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0, nullptr, nullptr};
 
     mmu_exception_handler = ppc_exception_handler;


### PR DESCRIPTION
Last `glob_bb_start_la` use was removed in d83fdd886658b6dda31c6ce40d6e53eb04024c40.

Last `last_read_area`, `last_write_area`, and `last_exec_area` uses were removed in c9d4cc3321c05e720b0664fd67dca1ae6b66c4de.