### PR TITLE
dbdma: update xferStatus and resCount when handling FLUSH command

### DIFF
--- a/devices/common/dbdma.cpp
+++ b/devices/common/dbdma.cpp
@@ -367,6 +367,11 @@ void DMAChannel::reg_write(uint32_t offset, uint32_t value, int size) {
                         this->dev_obj->notify(this, DMA_MSG_FLUSH);
                     if (this->flush_cb)
                         this->flush_cb();
+                    if (this->cur_is_writable) {
+                        WRITE_WORD_LE_A(&this->cur_host->xfer_stat,
+                                        this->ch_stat | CH_STAT_ACTIVE);
+                        WRITE_WORD_LE_A(&this->cur_host->res_count, this->res_count);
+                    }
                 }
             }
             this->ch_stat &= ~CH_STAT_FLUSH;


### PR DESCRIPTION
Per [the DBDMA](https://www.bitsavers.org/pdf/apple/powerpc/CHRP/chrp_io.pdf) spec (section 15.4.3), this is required:

> ChannelStatus.flush can be set to 1 by software, to force a channel that is executing an INPUT_MORE or INPUT_LAST command to update memory with any data that has been received from the device but has not yet been written to memory. When the memory update is complete, **hardware updates the xferStatus and resCount fields** in the current memory resident channel command, then clears the flush bit. Thus, a partial status update is characterized by 1 in the flush bit of the xferStatus field and a final status update is characterized by 0.

Fixes a hang when booting 9.0 and 9.0.4 on the Beige G3 (they would get stuck in a loop polling the `xferStatus.active` field).