### PR TITLE
ppcmmu: Ignore dcbz for MMIO regions

### DIFF
--- a/cpu/ppc/ppcmmu.cpp
+++ b/cpu/ppc/ppcmmu.cpp
@@ -864,6 +864,49 @@ static inline TLBEntry* lookup_secondary_tlb(uint32_t guest_va, uint32_t tag) {
     return tlb_entry;
 }
 
+void mmu_dcbz(uint32_t opcode, uint32_t guest_va)
+{
+    const uint32_t tag = guest_va & ~0xFFFUL;
+    // look up guest virtual address in the primary TLB
+    TLBEntry *tlb_entry = &pCurDTLB1[(guest_va >> PPC_PAGE_SIZE_BITS) & tlb_size_mask];
+
+    if (!tlb_entry->matches_tag(tag)) {
+        // primary TLB miss -> look up address in the secondary TLB
+        tlb_entry = lookup_secondary_tlb<TLBType::DTLB>(guest_va, tag);
+        if (tlb_entry == nullptr) {
+            // secondary TLB miss ->
+            // perform full address translation and refill the secondary TLB
+            tlb_entry = dtlb2_refill(guest_va, 1);
+        }
+    }
+
+    // Check if this was in a MMIO region, in which case we avoid doing the
+    // write, so that this intermediate state is not visible to the device
+    // (usually a dcbz is done to prepare a cache line as a write buffer, and
+    // the real values are written later).
+    if (tlb_entry->flags & TLBFlags::PAGE_IO) {
+        // Still do the same checks that mmu_write_vmem would have done to
+        // disallow writes to read-only regions.
+        if (!(tlb_entry->flags & TLBFlags::PAGE_WRITABLE)) {
+            ppc_state.spr[SPR::DSISR] = 0x08000000 | (1 << 25);
+            ppc_state.spr[SPR::DAR]   = guest_va;
+            mmu_exception_handler(Except_Type::EXC_DSI, 0);
+        }
+        if (!(tlb_entry->flags & TLBFlags::PTE_SET_C)) {
+            page_address_translation(guest_va, false, !!(ppc_state.msr & MSR::PR), true);
+            tlb_entry->flags |= TLBFlags::PTE_SET_C;
+        }
+        return;
+    }
+
+    // the following is not especially efficient but necessary
+    // to make BlockZero under Mac OS 8.x and later to work
+    mmu_write_vmem<uint64_t>(opcode, guest_va +  0, 0);
+    mmu_write_vmem<uint64_t>(opcode, guest_va +  8, 0);
+    mmu_write_vmem<uint64_t>(opcode, guest_va + 16, 0);
+    mmu_write_vmem<uint64_t>(opcode, guest_va + 24, 0);
+}
+
 uint8_t *mmu_translate_imem(uint32_t vaddr, uint32_t *paddr)
 {
 #if SUPPORTS_PPC_LITTLE_ENDIAN_MODE

--- a/cpu/ppc/ppcmmu.h
+++ b/cpu/ppc/ppcmmu.h
@@ -94,6 +94,7 @@ extern MapDmaResult mmu_map_dma_mem(uint32_t addr, uint32_t size, bool allow_mmi
 extern void mmu_change_mode(void);
 extern void mmu_pat_ctx_changed();
 extern void tlb_flush_entry(uint32_t ea);
+extern void mmu_dcbz(uint32_t opcode, uint32_t guest_va);
 
 extern uint64_t mem_read_dbg(uint32_t virt_addr, uint32_t size);
 extern void mem_write_dbg(uint32_t virt_addr, uint64_t value, int size);

--- a/cpu/ppc/ppcopcodes.cpp
+++ b/cpu/ppc/ppcopcodes.cpp
@@ -1616,12 +1616,7 @@ void dppc_interpreter::ppc_dcbz(uint32_t opcode) {
 
     ea &= 0xFFFFFFE0UL; // align EA on a 32-byte boundary
 
-    // the following is not especially efficient but necessary
-    // to make BlockZero under Mac OS 8.x and later to work
-    mmu_write_vmem<uint64_t>(opcode, ea +  0, 0);
-    mmu_write_vmem<uint64_t>(opcode, ea +  8, 0);
-    mmu_write_vmem<uint64_t>(opcode, ea + 16, 0);
-    mmu_write_vmem<uint64_t>(opcode, ea + 24, 0);
+    mmu_dcbz(opcode, ea);
 }
 
 


### PR DESCRIPTION
The ATI drivers uses dcbz to simulate a write-combining buffer when sending HOST_DATA payloads.

The intent is something like this (on real hardware):

```
dcbz:
    cache line = [0, 0, 0, 0, 0, 0, 0, 0]
    ATI sees nothing

following stores:
    cache line = [A, B, C, D, E, F, G, H]
    ATI still sees nothing

dcbf or eviction:
    write back [A, B, C, D, E, F, G, H]
    ATI receives one completed cache line
```

With our cacheless implementation, the behavior was more like this:
```
dcbz:
    ATI immediately receives [0, 0, 0, 0, 0, 0, 0, 0]

following stores:
    ATI then receives [A, B, C, D, E, F, G, H]

dcbf:
    no-op
```

The zero-ed out values have side effects (32 pixels of black being written), so the intermediate state was visible as visual corruption, especially visible when windows get redrawn on Mac OS 8.6.

The truly correct fix is to fully model the data cache, and do an eventual write back of the modified cache lines with their final values, but that is very invasive (and likely to be slow).

We instead just make `dcbz` a no-op for MMIO regions, which lets us avoid that intermediate state and unintended side effects.