### PR TITLE
atapibasedevice: Clear BSY and signal interrupt on unsupported ATA command

### DIFF
--- a/devices/common/ata/atapibasedevice.cpp
+++ b/devices/common/ata/atapibasedevice.cpp
@@ -201,6 +201,8 @@ int AtapiBaseDevice::perform_command() {
         LOG_F(ERROR, "%s: unsupported command 0x%X", this->name.c_str(), this->r_command);
         this->r_error  |= ATA_Error::ABRT;
         this->r_status |= ATA_Status::ERR;
+        this->r_status &= ~BSY;
+        this->update_intrq(1);
     }
     return 0;
 }

--- a/devices/common/scsi/scsicdrom.cpp
+++ b/devices/common/scsi/scsicdrom.cpp
@@ -47,8 +47,6 @@ ScsiCdrom::ScsiCdrom(std::string name, int my_id) : ScsiPhysDevice(name, my_id)
     this->set_vendor_id(my_vendor_id);
     this->set_product_id(my_product_id);
     this->set_revision_id(my_revision_id);
-
-    this->add_page_getter(this, 49, &ScsiCdrom::get_apple_page_49);
 }
 
 void ScsiCdrom::process_command() {
@@ -80,32 +78,6 @@ void ScsiCdrom::process_command() {
 // Apple SCSI/ATAPI driver requests this page in the case of a device error.
 // PearPC implements it under the name "Apple Features".
 // I couldn't find any drive whose firmware supports it.
-int ScsiCdrom::get_apple_page_49(uint8_t subpage, uint8_t ctrl, uint8_t *out_ptr,
-                                 int avail_len)
-{
-    LOG_F(WARNING, "Page 0x31 requested");
-
-    if (subpage && subpage != 0xFFU)
-        return FORMAT_ERR_BAD_SUBPAGE;
-
-    if (ctrl == 3)
-        return FORMAT_ERR_BAD_CONTROL;
-
-    int page_size = 6;
-
-    if (page_size > avail_len)
-        return FORMAT_ERR_DATA_TOO_BIG;
-
-    std::memset(out_ptr, 0, page_size);
-
-    out_ptr[0] = '.';
-    out_ptr[1] = 'A';
-    out_ptr[2] = 'p';
-    out_ptr[3] = 'p';
-
-    return page_size;
-}
-
 void ScsiCdrom::mode_select_6(uint8_t param_len)
 {
     if (!param_len)

--- a/devices/common/scsi/scsicdrom.h
+++ b/devices/common/scsi/scsicdrom.h
@@ -45,9 +45,6 @@ public:
 protected:
     bool is_device_ready() override { return this->is_ready; }
 
-    int  get_apple_page_49(uint8_t subpage, uint8_t ctrl, uint8_t *out_ptr,
-                          int avail_len);
-
     void mode_select_6(uint8_t param_len);
 
 private:

--- a/devices/common/scsi/scsicdromcmds.cpp
+++ b/devices/common/scsi/scsicdromcmds.cpp
@@ -36,6 +36,9 @@ ScsiCdromCmds::ScsiCdromCmds() {
 
     this->add_page_getter(this, ModePage::CDROM_CAPABILITIES,
                           &ScsiCdromCmds::get_cd_capabilities_page);
+
+    this->add_page_getter(this, ModePage::VENDOR_PAGE_31,
+                          &ScsiCdromCmds::get_apple_page_49);
 }
 
 void ScsiCdromCmds::process_command() {
@@ -221,6 +224,34 @@ int ScsiCdromCmds:: read_toc() {
     phy_impl->set_xfer_len(std::min(alloc_len, resp_len));
 
     return ScsiPhase::DATA_IN;
+}
+
+// Apple SCSI/ATAPI driver requests this page in the case of a device error.
+// PearPC implements it under the name "Apple Features".
+int ScsiCdromCmds::get_apple_page_49(uint8_t subpage, uint8_t ctrl,
+                                     uint8_t *out_ptr, int avail_len)
+{
+    LOG_F(WARNING, "Page 0x31 requested");
+
+    if (subpage && subpage != 0xFFU)
+        return FORMAT_ERR_BAD_SUBPAGE;
+
+    if (ctrl == 3)
+        return FORMAT_ERR_BAD_CONTROL;
+
+    int page_size = 6;
+
+    if (page_size > avail_len)
+        return FORMAT_ERR_DATA_TOO_BIG;
+
+    std::memset(out_ptr, 0, page_size);
+
+    out_ptr[0] = '.';
+    out_ptr[1] = 'A';
+    out_ptr[2] = 'p';
+    out_ptr[3] = 'p';
+
+    return page_size;
 }
 
 int ScsiCdromCmds::set_cd_speed() {

--- a/devices/common/scsi/scsicdromcmds.h
+++ b/devices/common/scsi/scsicdromcmds.h
@@ -36,6 +36,9 @@ public:
 protected:
     virtual void process_command() override;
 
+    int get_apple_page_49(uint8_t subpage, uint8_t ctrl,
+                          uint8_t *out_ptr, int avail_len);
+
     int read_toc();
     int set_cd_speed();
 


### PR DESCRIPTION
## Summary

The ATAPI CD-ROM hung Open Firmware during device probing on the Power Mac G3 beige, leaving a grey screen with a cursor after the 3rd display extension init.

## Root cause

`AtapiBaseDevice::perform_command()` default case set the ABRT/ERR bits but left `BSY` asserted and never fired the interrupt. When Open Firmware issued an unsupported ATA command during its boot device probe (0xEC IDENTIFY_DEVICE), the device stayed busy forever and the machine never progressed past probing the CD-ROM.

## Changes

1. **atapibasedevice.cpp** - On unsupported ATA command, clear `BSY` and call `update_intrq(1)` so the host receives a proper error status and can continue, matching the other command paths and the behavior in `AtaHardDisk`.
2. **scsicdromcmds** - Move the Apple Features MODE_SENSE page 0x31 getter from `ScsiCdrom` into `ScsiCdromCmds` so it is registered for the ATAPI CD-ROM as well as the SCSI one. The Mac OS driver requests this page on device errors; the ATAPI path previously replied "page not supported".

## Verification

Booting Mac OS 9.2.2 from the install CD on the Power Mac G3 beige with a 256 MB RAM bank now proceeds past the point where it previously hung. No compiler warnings.