### PR TITLE
sdl: allow screensaver

### DIFF
--- a/main_sdl.cpp
+++ b/main_sdl.cpp
@@ -35,6 +35,8 @@ bool init() {
         return false;
     }
 
+    SDL_EnableScreenSaver();
+
     int num_joysticks = SDL_NumJoysticks();
     for (int i = 0; i < num_joysticks; ++i) {
         if (SDL_IsGameController(i)) {


### PR DESCRIPTION
SDL defaults to disabling the screensaver, which on macOS hosts also means that the display or machine will not sleep. This is appropriate for games, but not for a regular windowed application like DingusPPC (if a session is left running in the background).