### PR TITLE
ata: Advertise multiword DMA support

### DIFF
--- a/devices/common/ata/atahd.cpp
+++ b/devices/common/ata/atahd.cpp
@@ -289,7 +289,7 @@ void AtaHardDisk::prepare_identify_info() {
     std::memset(this->data_buf, 0, sizeof(this->data_buf));
 
     WRITE_WORD_LE_A(&buf_ptr[ 0], 0x0040); // ATA device, non-removable media, non-removable drive
-    WRITE_WORD_LE_A(&buf_ptr[49], 0x0200); // report LBA support
+    WRITE_WORD_LE_A(&buf_ptr[49], 0x0300); // report DMA and LBA support
 
     // Maximum number of logical sectors per data block that the device supports
     // for READ_MULTIPLE/WRITE_MULTIPLE commands.
@@ -307,8 +307,8 @@ void AtaHardDisk::prepare_identify_info() {
 
     WRITE_WORD_LE_A(&buf_ptr[51], 0x0200); // max. PIO mode for a basic device
 
-    // report validity for the advanced PIO and MWDMA fields
-    //WRITE_WORD_LE_A(&buf_ptr[53], 0x0003);
+    // report validity for the MWDMA fields
+    WRITE_WORD_LE_A(&buf_ptr[53], 0x0002);
 
     WRITE_DWORD_LE_A(&buf_ptr[57], this->total_sectors);
 
@@ -316,6 +316,8 @@ void AtaHardDisk::prepare_identify_info() {
     WRITE_DWORD_LE_A(&buf_ptr[60], this->total_sectors);
 
     WRITE_WORD_LE_A(&buf_ptr[63], ((1 << this->cur_dma_mode) << 8) | 7);
+    WRITE_WORD_LE_A(&buf_ptr[65], 120); // minimum MWDMA cycle time (ns)
+    WRITE_WORD_LE_A(&buf_ptr[66], 120); // recommended MWDMA cycle time (ns)
 }
 
 uint64_t AtaHardDisk::get_lba() {


### PR DESCRIPTION
Followup to #192. That implemented DMA support, but did not advertise it via the IDENTIFY command. While the 10.0 public beta used it unconditionally, later releases will only use it if the hardware reports the MWDMA bit.

DMA is more efficient than PIO (less time spent in the CPU emulator); this takes booting 10.3 (to WindowServer startup) from ~60 seconds to ~47 seconds on my machine.