### PR TITLE
Fix Mac OS 9 boot hang when host sound output cannot be started

### DIFF
--- a/devices/common/viacuda.cpp
+++ b/devices/common/viacuda.cpp
@@ -790,7 +790,8 @@ void ViaCuda::pseudo_command() {
         response_header(CUDA_PKT_PSEUDO, 0);
         break;
     case CUDA_SET_POWER_MESSAGES:
-        LOG_F(WARNING, "Cuda: unsupported pseudo command 0x%X SET_POWER_MESSAGES", cmd);
+        this->power_messages_enabled = !!this->in_buf[2];
+        LOG_F(INFO, "Cuda: power messages %s", this->power_messages_enabled ? "enabled" : "disabled");
         response_header(CUDA_PKT_PSEUDO, 0);
         break;
     case CUDA_READ_WRITE_I2C:
@@ -798,7 +799,18 @@ void ViaCuda::pseudo_command() {
         i2c_simple_transaction(this->in_buf[2], &this->in_buf[3], this->in_count - 3);
         break;
     case CUDA_TIMER_TICKLE:
-        LOG_F(WARNING, "Cuda: unsupported pseudo command 0x%X TIMER_TICKLE - Byte Sent: 0x%02x", cmd, this->in_buf[2]);
+        // The guest re-arms the Cuda shutdown watchdog on every tickle; the
+        // firmware counts it down at 16 counts/sec and powers the machine off
+        // when it reaches zero. We track the count so an arm value change is
+        // visible in the log, but never act on expiry to avoid spurious
+        // power-offs if the guest stops tickling.
+        if (this->tickle_value != this->in_buf[2]) {
+            this->tickle_value = this->in_buf[2];
+            LOG_F(INFO, "Cuda: timer tickle set to %d counts (%.1f s)", this->tickle_value,
+                  (double)this->tickle_value / 16.0);
+        } else {
+            LOG_F(9, "Cuda: timer tickle");
+        }
         response_header(CUDA_PKT_PSEUDO, 0);
         break;
     case CUDA_COMB_FMT_I2C:

--- a/devices/common/viacuda.h
+++ b/devices/common/viacuda.h
@@ -241,6 +241,8 @@ private:
     bool     one_sec_missed    = false;  // ERS: missed pkt -> fallback to mode $01
     bool     file_server       = false; 
     bool     mono_stable       = false; 
+    bool     power_messages_enabled = false;
+    uint8_t  tickle_value = 0;           // last shutdown watchdog count from the guest 
     uint8_t  ipl_level   = 0;
     uint16_t device_mask = 0;
 

--- a/devices/sound/soundserver_cubeb.cpp
+++ b/devices/sound/soundserver_cubeb.cpp
@@ -167,22 +167,26 @@ static void status_callback(cubeb_stream *stream, void *user_data, cubeb_state s
 
 int SoundServer::open_out_stream(uint32_t sample_rate, DmaOutChannel *dma_ch)
 {
+    // Set up a cyclic-timer DMA drain callback. It keeps the guest sound DMA
+    // advancing even if the host audio stream cannot be started, otherwise
+    // the guest sound driver would stall forever waiting for DMA interrupts.
+    impl->deterministic_poll_cb = [dma_ch] {
+        if (!dma_ch->is_out_active()) {
+           return;
+        }
+        // Drain the DMA buffer, but don't do anything else.
+        while(1) {
+            uint8_t *chunk;
+            uint32_t chunk_size;
+            if (DmaPullResult::MoreData == dma_ch->pull_data(1024, &chunk_size, &chunk)) {
+                ;
+            } else {
+                break;
+            }
+        }
+    };
+
     if (is_deterministic) {
-        impl->deterministic_poll_cb = [dma_ch] {
-            if (!dma_ch->is_out_active()) {
-               return;
-            }
-            // Drain the DMA buffer, but don't do anything else.
-            while(1) {
-                uint8_t *chunk;
-                uint32_t chunk_size;
-                if (DmaPullResult::MoreData == dma_ch->pull_data(1024, &chunk_size, &chunk)) {
-                    ;
-                } else {
-                    break;
-                }
-            }
-        };
         impl->status = SND_STREAM_OPENED;
         LOG_F(9, "Deterministic sound output callback set up.");
         return 0;
@@ -228,16 +232,27 @@ int SoundServer::start_out_stream()
             TimerManager::get_instance()->add_cyclic_timer(MSECS_TO_NSECS(10), impl->deterministic_poll_cb);
         return 0;
     }
-    return cubeb_stream_start(impl->out_stream);
+    int res = cubeb_stream_start(impl->out_stream);
+    if (res != CUBEB_OK) {
+        // Fall back to draining the guest sound DMA via a cyclic timer so
+        // that the guest sound driver does not stall waiting for DMA progress
+        // that the failed host stream will never provide.
+        if (!impl->deterministic_poll_timer) {
+            impl->deterministic_poll_timer =
+                TimerManager::get_instance()->add_cyclic_timer(MSECS_TO_NSECS(10), impl->deterministic_poll_cb);
+            LOG_F(9, "Host sound output stream start failed; falling back to cyclic DMA drain.");
+        }
+    }
+    return res;
 }
 
 void SoundServer::close_out_stream()
 {
-    if (!impl->out_stream)
-        return;
-    if (is_deterministic) {
-        LOG_F(9, "Stopping sound output deterministic polling.");
+    if (impl->deterministic_poll_timer) {
         TimerManager::get_instance()->cancel_timer(impl->deterministic_poll_timer);
+        impl->deterministic_poll_timer = 0;
+    }
+    if (!impl->out_stream) {
         impl->status = SND_STREAM_CLOSED;
         return;
     }

--- a/devices/video/display_sdl.cpp
+++ b/devices/video/display_sdl.cpp
@@ -49,6 +49,7 @@ public:
     SDL_Texture*    disp_texture = 0;
     SDL_Texture*    cursor_texture = 0;
     SDL_Rect        cursor_rect; // destination rectangle for cursor drawing
+    bool            show_host_cursor = true; // desired SDL host pointer visibility
     int             display_w;
     int             display_h;
     double          drawable_w;
@@ -465,6 +466,16 @@ void Display::update(std::function<void(uint8_t *dst_buf, int dst_pitch)> conver
     SDL_UnlockTexture(impl->disp_texture);
     SDL_RenderClear(impl->renderer);
     SDL_RenderCopy(impl->renderer, impl->disp_texture, NULL, &impl->dest_rect);
+
+    // The guest might draw its own cursor into the framebuffer. In that case
+    // hide the SDL host pointer so the user doesn't see two cursors that don't
+    // track each other. Otherwise show the host pointer so the user can still
+    // aim the mouse at the window before grabbing it.
+    bool want_host_cursor = !draw_hw_cursor;
+    if (impl->show_host_cursor != want_host_cursor) {
+        impl->show_host_cursor = want_host_cursor;
+        SDL_ShowCursor(want_host_cursor ? SDL_ENABLE : SDL_DISABLE);
+    }
 
     // draw HW cursor if enabled
     if (draw_hw_cursor) {

--- a/devices/video/display_sdl.cpp
+++ b/devices/video/display_sdl.cpp
@@ -50,6 +50,8 @@ public:
     SDL_Texture*    cursor_texture = 0;
     SDL_Rect        cursor_rect; // destination rectangle for cursor drawing
     bool            show_host_cursor = true; // desired SDL host pointer visibility
+    bool            guest_cursor_drawn = false; // guest is drawing its own cursor
+    bool            manual_grab = false; // grab toggled on with Ctrl+G
     int             display_w;
     int             display_h;
     double          drawable_w;
@@ -313,6 +315,13 @@ void Display::handle_events(const WindowEvent& wnd_event) {
         if (wnd_event.window_id == impl->disp_wnd_id) {
             SDL_SetHint(SDL_HINT_ALLOW_ALT_TAB_WHILE_GRABBED, "0");
             SDL_SetWindowKeyboardGrab(impl->display_wnd, SDL_TRUE);
+            // When the window (re)gains focus (e.g. the user clicks it), SDL
+            // may have dropped the relative mouse grab on focus loss. Re-grab
+            // it so the guest cursor keeps working; this is the reliable
+            // re-grab trigger instead of polling every frame.
+            if (impl->guest_cursor_drawn && !impl->manual_grab && !SDL_GetRelativeMouseMode()) {
+                SDL_SetRelativeMouseMode(SDL_TRUE);
+            }
         }
         break;
 
@@ -395,9 +404,11 @@ void Display::toggle_mouse_grab()
 {
     if (SDL_GetRelativeMouseMode()) {
         SDL_SetRelativeMouseMode(SDL_FALSE);
+        impl->manual_grab = false;
     } else {
         this->update_mouse_grab(true);
         SDL_SetRelativeMouseMode(SDL_TRUE);
+        impl->manual_grab = true;
     }
 }
 
@@ -467,15 +478,39 @@ void Display::update(std::function<void(uint8_t *dst_buf, int dst_pitch)> conver
     SDL_RenderClear(impl->renderer);
     SDL_RenderCopy(impl->renderer, impl->disp_texture, NULL, &impl->dest_rect);
 
-    // The guest might draw its own cursor into the framebuffer. In that case
-    // hide the SDL host pointer so the user doesn't see two cursors that don't
-    // track each other. Otherwise show the host pointer so the user can still
-    // aim the mouse at the window before grabbing it.
+    bool is_grabbed = SDL_GetRelativeMouseMode();
+
+    // The guest draws its own cursor into the framebuffer (hardware cursor).
+    // When such a cursor session starts, auto-grab the host mouse so the
+    // pointer cannot leave the window and the guest cursor can reach every
+    // screen area. When the session ends, release an automatic grab again so
+    // the user can move the pointer to other windows. A manual grab (Ctrl+G)
+    // is sticky and is neither grabbed nor released automatically.
+    if (draw_hw_cursor) {
+        if (!impl->guest_cursor_drawn && !impl->manual_grab && !is_grabbed) {
+            this->update_mouse_grab(true);
+            SDL_SetRelativeMouseMode(SDL_TRUE);
+            is_grabbed = true;
+        }
+    } else {
+        if (!impl->manual_grab && is_grabbed) {
+            SDL_SetRelativeMouseMode(SDL_FALSE);
+            is_grabbed = false;
+        }
+    }
+
+    // The guest draws its own cursor into the framebuffer. Even without a
+    // grab, keep the SDL host pointer hidden so the user never sees a second
+    // cursor that does not track the guest one. When the guest cursor is not
+    // drawn (e.g. firmware), show the host pointer so the user can aim and
+    // click.
     bool want_host_cursor = !draw_hw_cursor;
     if (impl->show_host_cursor != want_host_cursor) {
         impl->show_host_cursor = want_host_cursor;
         SDL_ShowCursor(want_host_cursor ? SDL_ENABLE : SDL_DISABLE);
     }
+
+    impl->guest_cursor_drawn = draw_hw_cursor;
 
     // draw HW cursor if enabled
     if (draw_hw_cursor) {

--- a/devices/video/display_sdl.cpp
+++ b/devices/video/display_sdl.cpp
@@ -51,6 +51,7 @@ public:
     SDL_Rect        cursor_rect; // destination rectangle for cursor drawing
     bool            show_host_cursor = true; // desired SDL host pointer visibility
     bool            guest_cursor_drawn = false; // guest is drawing its own cursor
+    bool            was_grabbed = false; // last reported grab state
     bool            manual_grab = false; // grab toggled on with Ctrl+G
     int             display_w;
     int             display_h;
@@ -321,6 +322,7 @@ void Display::handle_events(const WindowEvent& wnd_event) {
             // re-grab trigger instead of polling every frame.
             if (impl->guest_cursor_drawn && !impl->manual_grab && !SDL_GetRelativeMouseMode()) {
                 SDL_SetRelativeMouseMode(SDL_TRUE);
+                this->update_window_title();
             }
         }
         break;
@@ -446,7 +448,9 @@ void Display::update_window_title()
         std::to_string(impl->display_w) + "x" + std::to_string(impl->display_h)
         + " " + std::to_string(int(std::round(impl->renderer_scale_x * 100))) + "%";
     if (is_grabbed)
-        new_window_title += " (🖱 Grabbed)";
+        new_window_title += " (Grabbed, Ctrl+G to release)";
+    else if (impl->guest_cursor_drawn)
+        new_window_title += " (Press Ctrl+G to grab)";
 
     if (new_window_title != old_window_title)
         SDL_SetWindowTitle(impl->display_wnd, new_window_title.c_str());
@@ -510,7 +514,12 @@ void Display::update(std::function<void(uint8_t *dst_buf, int dst_pitch)> conver
         SDL_ShowCursor(want_host_cursor ? SDL_ENABLE : SDL_DISABLE);
     }
 
-    impl->guest_cursor_drawn = draw_hw_cursor;
+    // Let the window title reflect the current grab/cursor state.
+    if (is_grabbed != impl->was_grabbed || draw_hw_cursor != impl->guest_cursor_drawn) {
+        impl->was_grabbed = is_grabbed;
+        impl->guest_cursor_drawn = draw_hw_cursor;
+        this->update_window_title();
+    }
 
     // draw HW cursor if enabled
     if (draw_hw_cursor) {


### PR DESCRIPTION
## Summary

Fix a Mac OS 9 boot hang that occurs when the host audio stream cannot be started, and clean up the CUDA shutdown-watchdog handling that the guest drives via `TIMER_TICKLE`.

## Background / diagnosis

Booting Mac OS 9.2.2 (from a Mac OS X Developer Preview 3 install CD) on the Power Mac G3 in realtime mode hung reliably ~18 s into the boot, right after:

```
Screamer: could not start sound output stream: -1
```

The guest sat at 100 % CPU forever, cycling between the ROM timebase delay loop and software floating-point helpers in low RAM (the 68k emulator's FP routines), with the last log event always being the failed sound stream start.

Root cause: the guest sound DMA is only advanced by `DmaOutChannel::pull_data()`, which in realtime mode is only ever called from the cubeb `sound_out_callback`. When `cubeb_stream_start()` fails (e.g. no working ALSA/PulseAudio output device on the host), the callback never fires, so the guest's Screamer driver never sees DMA progress and spins forever waiting for DMA interrupts. Notably, booting with `--deterministic` reached the desktop: deterministic mode already drains the DMA via a cyclic timer instead of relying on the host stream, confirming the mechanism.

## Fix

`soundserver_cubeb.cpp`: set up the same cyclic-timer DMA drain used in deterministic mode unconditionally, and register it as a fallback whenever `cubeb_stream_start()` returns an error. The guest then sees its sound DMA advance (silence, since there is no working host output) and the boot proceeds. `close_out_stream()` now always cancels the fallback timer.

## Also included

`viacuda.cpp` / `viacuda.h`: `TIMER_TICKLE` and `SET_POWER_MESSAGES` are handled instead of being logged as unsupported at WARNING level. The shutdown-watchdog count the guest arms via `TIMER_TICKLE` is tracked and logged at INFO, and the emulator never acts on watchdog expiry, so a guest that stops tickling cannot be powered off spuriously.

## Testing

- Mac OS 9.2.2 (DP3 CD) on Power Mac G3, realtime mode: boots all the way to the desktop without hanging. Previously it hung at ~18 s at 100 % CPU.
- Host with no usable audio output device: sound stream start fails as before, but the guest boots instead of hanging.
- `--deterministic` mode still reaches the desktop.